### PR TITLE
Put `total-popn` and `current-yr-in-loop` back in the loop

### DIFF
--- a/src/witan/send/model.clj
+++ b/src/witan/send/model.clj
@@ -20,8 +20,6 @@
    [:get-historic-population :add-extra-population]
    [:population-change :add-extra-population]
    [:add-extra-population :select-starting-population]
-   [:get-current-year :select-starting-population]
-   [:add-extra-population :append-to-total-population]
 
    ;;Loop
    [:select-starting-population :apply-state-changes]
@@ -83,11 +81,7 @@
    {:witan/name :add-extra-population
     :witan/version "1.0.0"
     :witan/type :function
-    :witan/fn :send/add-extra-population}
-   {:witan/name :get-current-year
-    :witan/version "1.0.0"
-    :witan/type :function
-    :witan/fn :send/get-current-year
+    :witan/fn :send/add-extra-population
     :witan/params {:projection-start-year 2017}}
 
    ;;Workflow functions in the loop
@@ -144,7 +138,6 @@
                    send/get-historic-population-1-0-0
                    send/population-change-1-0-0
                    send/add-extra-population-1-0-0
-                   send/get-current-year-1-0-0
                    send/select-starting-population-1-0-0
                    send/apply-state-changes-1-0-0
                    send/get-transition-matrix-1-0-0

--- a/src/witan/send/send.clj
+++ b/src/witan/send/send.clj
@@ -74,18 +74,12 @@
    :witan/version "1.0.0"
    :witan/input-schema {:historic-population sc/SENDSchemaIndividual
                         :extra-population sc/SENDSchemaIndividual}
-   :witan/output-schema {:total-population sc/SENDSchemaIndividual}}
-  [{:keys [historic-population extra-population]} _]
-  {:total-population {}})
-
-(defworkflowfn get-current-year-1-0-0
-  {:witan/name :send/get-current-year
-   :witan/version "1.0.0"
-   :witan/input-schema {}
    :witan/param-schema {:projection-start-year sc/YearSchema}
-   :witan/output-schema {:current-year-in-loop sc/YearSchema}}
-  [_ {:keys [projection-start-year]}]
-  {:current-year-in-loop projection-start-year})
+   :witan/output-schema {:total-population sc/SENDSchemaIndividual
+                         :current-year-in-loop sc/YearSchema}}
+  [{:keys [historic-population extra-population]} {:keys [projection-start-year]}]
+  {:total-population {}
+   :current-year-in-loop projection-start-year})
 
 ;;Functions in loop
 (defworkflowfn select-starting-population-1-0-0
@@ -94,9 +88,11 @@
    :witan/input-schema {:total-population sc/SENDSchemaIndividual
                         :current-year-in-loop sc/YearSchema}
    :witan/output-schema {:current-population sc/SENDSchemaIndividual
+                         :total-population sc/SENDSchemaIndividual
                          :current-year-in-loop sc/YearSchema}}
   [{:keys [total-population current-year-in-loop]} _]
   {:current-population {}
+   :total-population total-population
    :current-year-in-loop current-year-in-loop})
 
 (defworkflowfn get-transition-matrix-1-0-0
@@ -114,11 +110,14 @@
    :witan/version "1.0.0"
    :witan/input-schema {:current-population sc/SENDSchemaIndividual
                         :transition-matrix sc/TransitionMatrix
+                        :total-population sc/SENDSchemaIndividual
                         :current-year-in-loop sc/YearSchema}
    :witan/output-schema {:current-population sc/SENDSchemaIndividual
+                         :total-population sc/SENDSchemaIndividual
                          :current-year-in-loop sc/YearSchema}}
-  [{:keys [current-population transition-matrix current-year-in-loop]} _]
+  [{:keys [current-population transition-matrix total-population current-year-in-loop]} _]
   {:current-population {}
+   :total-population total-population
    :current-year-in-loop current-year-in-loop})
 
 (defworkflowfn append-to-total-population-1-0-0


### PR DESCRIPTION
`total-population` and `current-year-in-loop` are both added to the `add-extra-population` function and go through the loop where they are used by the function `append-to-total-population`.