### PR TITLE
Feature/apply modified joiners elsewhere

### DIFF
--- a/data/demo/modify-settings.csv
+++ b/data/demo/modify-settings.csv
@@ -1,0 +1,3 @@
+setting-1,setting-2
+MMSOB,MMSOB
+MMSIB,MMSIB

--- a/src/clj/witan/send/model.clj
+++ b/src/clj/witan/send/model.clj
@@ -7,7 +7,8 @@
 
 (def send-model-workflow
   "Defines each step of the model"
-  [[:initial-send-population :prepare-send-inputs]
+  [[:settings-to-change :prepare-send-inputs]
+   [:initial-send-population :prepare-send-inputs]
    [:transition-matrix :prepare-send-inputs]
    [:population :prepare-send-inputs]
    [:setting-cost :prepare-send-inputs]
@@ -17,7 +18,12 @@
 
 (def send-model-catalog
   "Provides metadata for each step in the model"
-  [{:witan/name :initial-send-population
+  [{:witan/name :settings-to-change
+    :witan/version "1.0.0"
+    :witan/type :input
+    :witan/fn :send/settings-to-change
+    :witan/params {:src ""}}
+   {:witan/name :initial-send-population
     :witan/version "1.0.0"
     :witan/type :input
     :witan/fn :send/initial-send-population
@@ -46,7 +52,7 @@
     :witan/version "1.0.0"
     :witan/type :function
     :witan/fn :send/prepare-send-inputs
-    :witan/params {:multiply-transition-by 1}}
+    :witan/params {:modify-transition-by 1}}
    {:witan/name :run-send-model
     :witan/version "1.0.0"
     :witan/type :function
@@ -73,7 +79,8 @@
   []
   (reify p/IModelLibrary
     (available-fns [_]
-      (map-fn-meta send/initial-send-population-1-0-0
+      (map-fn-meta send/settings-to-change-1-0-0
+                   send/initial-send-population-1-0-0
                    send/transition-matrix-1-0-0
                    send/population-1-0-0
                    send/setting-cost-1-0-0

--- a/src/clj/witan/send/schemas.clj
+++ b/src/clj/witan/send/schemas.clj
@@ -90,6 +90,10 @@
     (s/one s/Keyword :state)]
    {s/Keyword R}})
 
+(def SettingsToChange
+  (make-ordered-ds-schema [[:setting-1 s/Keyword]
+                           [:setting-2 s/Keyword]]))
+
 (def SENDPopulation
   (make-ordered-ds-schema [[:calendar-year CalendarYear]
                            [:academic-year AcademicYear]

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -391,7 +391,6 @@
                    (do (println "Reducing...")
                        (transduce (map #(map :model %)) (reduce-rf iterations valid-states setting-cost-lookup) projection))))
         projection (apply concat projections)]
-    (output-transitions "target/transitions.edn" projection)
     ;;    (println mover-beta-params)
     (println "Combining...")
     {:projection (projection->transitions projection)
@@ -490,6 +489,7 @@
             mover-rates-CI (map #(confidence-interval mover-rates %) years)
             ;;n-colours (vec (repeatedly (count years) ch/random-colour)) ;; alternative random colour selection
             n-colours (take (count years) ch/palette)]
+        (output-transitions "target/transitions.edn" projection)
         (with-open [writer (io/writer (io/file "target/output-ay-state.csv"))]
           (let [columns [:calendar-year :academic-year :state :mean :std-dev :iqr :min :low-ci :q1 :median :q3 :high-ci :max]]
             (->> (mapcat (fn [output year]

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -120,6 +120,12 @@
 
 ;; Workflow functions
 
+(definput settings-to-change-1-0-0
+  {:witan/name :send/settings-to-change
+   :witan/version "1.0.0"
+   :witan/key :settings-to-change
+   :witan/schema sc/SettingsToChange})
+
 (definput initial-send-population-1-0-0
   {:witan/name :send/initial-send-population
    :witan/version "1.0.0"
@@ -201,12 +207,13 @@
    row for each individual/year/simulation. Also includes age & state columns"
   {:witan/name :send/prepare-send-inputs
    :witan/version "1.0.0"
-   :witan/input-schema {:population sc/PopulationDataset
+   :witan/input-schema {:settings-to-change sc/SettingsToChange
+                        :population sc/PopulationDataset
                         :initial-send-population sc/SENDPopulation
                         :transition-matrix sc/TransitionCounts
                         :setting-cost sc/NeedSettingCost
                         :valid-setting-academic-years sc/ValidSettingAcademicYears}
-   :witan/param-schema {:multiply-transition-by s/Num}
+   :witan/param-schema {:modify-transition-by s/Num}
    :witan/output-schema {:population-by-age-state sc/ModelState
                          :projected-population sc/PopulationByCalendarAndAcademicYear
                          :joiner-beta-params sc/JoinerBetaParams
@@ -218,9 +225,9 @@
                          :valid-setting-academic-years sc/ValidSettingAcademicYears
                          :transition-matrix sc/TransitionCounts
                          :population sc/PopulationDataset}}
-  [{:keys [initial-send-population transition-matrix population
+  [{:keys [settings-to-change initial-send-population transition-matrix population
            setting-cost valid-setting-academic-years]}
-   {:keys [multiply-transition-by]}]
+   {:keys [modify-transition-by]}]
   (let [original-transitions transition-matrix
         ages (distinct (map :academic-year (ds/row-maps population)))
         years (distinct (map :calendar-year (ds/row-maps population)))

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -178,33 +178,22 @@
            {} a)
    b))
 
-(def states-to-halve
-  "List of states to change for TH alternative scenario"
-  [:CI-MSSOB
-   :CI-MMSOB
-   :CI-MUOB
-   :CL-MSSOB
-   :CL-MMSOB
-   :CL-MUOB
-   :OTH-MSSOB
-   :OTH-MMSOB
-   :OTH-MUOB
-   :SEMH-MSSOB
-   :SEMH-MMSOB
-   :SEMH-MUOB
-   :SP-MSSOB
-   :SP-MMSOB
-   :SP-MUOB
-   :UKN-MSSOB
-   :UKN-MMSOB
-   :UKN-MUOB])
+(defn generate-transition-key [cy ay need setting]
+  (vector cy ay :NONSEND (states/state need setting)))
 
-(defn generate-transition-key [cy ay state]
-  (vector cy ay :NONSEND state))
+(defn update-ifelse-assoc [m k arithmetic-fn v]
+  (if (contains? m k)
+    (update m k #(arithmetic-fn % v))
+    (assoc m k v)))
 
-(defn modify-transition-count [transitions k modifier v]
-  (if (contains? transitions k)
-    (update transitions k #(u/int-ceil (modifier % v)))
+(defn modify-transitions [transitions [first-state second-state] arithmetic-fn v]
+  (if (contains? transitions first-state)
+    (let [pop (get transitions first-state)
+          mod-pop (u/int-ceil (arithmetic-fn pop v))
+          diff (- pop mod-pop)]
+      (-> transitions
+          (assoc first-state mod-pop)
+          (update-ifelse-assoc second-state + diff)))
     transitions))
 
 (defworkflowfn prepare-send-inputs-1-0-0
@@ -235,17 +224,26 @@
   (let [original-transitions transition-matrix
         ages (distinct (map :academic-year (ds/row-maps population)))
         years (distinct (map :calendar-year (ds/row-maps population)))
-        keys-to-change (vec (mapcat (fn [cy] (mapcat (fn [ay]
-                                                       (map (fn [state] (generate-transition-key cy ay state))
-                                                            states-to-halve)) ages)) years))
-        transition-matrix (if (= 1 multiply-transition-by)
+        valid-needs (->> (ds/row-maps valid-setting-academic-years)
+                         (states/calculate-valid-needs-from-setting-academic-years))
+        states-to-change (if (= 1 modify-transition-by)
+                           nil
+                           (let [state-pairs (->> settings-to-change
+                                                  ds/row-maps
+                                                  (map #(vector (:setting-1 %) (:setting-2 %))))]
+                             (vec (mapcat (fn [year]
+                                            (mapcat (fn [age]
+                                                      (mapcat (fn [need]
+                                                                (map (fn [setting] (vector (generate-transition-key age year need (first setting))
+                                                                                           (generate-transition-key age year need (second setting))))
+                                                                     state-pairs)) valid-needs)) ages)) years))))
+        transition-matrix (if (= 1 modify-transition-by)
                             (ds/row-maps transition-matrix)
                             (let [convert (-> transition-matrix
                                               ds/row-maps
                                               u/full-transitions-map)
-                                  result (reduce (fn [m k] (modify-transition-count m k * multiply-transition-by)) convert keys-to-change)]
+                                  result (reduce (fn [m k] (modify-transitions m k * modify-transition-by)) convert states-to-change)]
                               (mapcat (fn [[k v]] (u/back-to-transitions-matrix k v)) result)))
-        ;;; take the same states here, check their count, divide by n, sum total across a need, then apply where?
         transitions (u/transitions-map transition-matrix)
         transition-matrix-filtered (filter #(= (:calendar-year %) 2016) transition-matrix)
 
@@ -253,9 +251,6 @@
 
         valid-settings (->> (ds/row-maps valid-setting-academic-years)
                             (states/calculate-valid-settings-from-setting-academic-years))
-
-        valid-needs (->> (ds/row-maps valid-setting-academic-years)
-                         (states/calculate-valid-needs-from-setting-academic-years))
 
         valid-states (->> (ds/row-maps valid-setting-academic-years)
                           (states/calculate-valid-states-from-setting-academic-years))

--- a/test/witan/send/acceptance/workspace_test.clj
+++ b/test/witan/send/acceptance/workspace_test.clj
@@ -20,9 +20,9 @@
    :valid-setting-academic-years [(str "data/" inputs-path "valid-setting-academic-years.csv") sc/ValidSettingAcademicYears]})
 
 (defn add-input-params
-  [input]
+  [file-map input]
   (assoc-in input [:witan/params :fn] (fn [a b]
-                                        (tu/read-inputs (test-inputs) input a b))))
+                                        (tu/read-inputs file-map input a b))))
 
 (witan.workspace-api/set-api-logging! println)
 
@@ -41,16 +41,26 @@
       (is (= #{:total-in-send-by-ay :total-in-send-by-ay-group :by-state :total-cost :total-in-send :total-in-send-by-need :total-in-send-by-setting}
              (-> result first keys set))))))
 
-(defn run-model [iterations output? transition-multiplier]
-  (let [fixed-catalog (->> (:catalog m/send-model)
-                           (mapv #(if (= (:witan/type %) :input)
-                                    (add-input-params %)
-                                    (assoc-in % [:witan/params :simulations] iterations)))
-                           (map #(assoc-in % [:witan/params :output] output?))
-                           (map #(assoc-in % [:witan/params :multiply-transition-by] transition-multiplier)))
-        workspace     {:workflow  (:workflow m/send-model)
-                       :catalog   fixed-catalog
-                       :contracts (p/available-fns (m/model-library))}
-        workspace'    (s/with-fn-validation (wex/build! workspace))
-        result        (apply merge (wex/run!! workspace' {}))]
-    nil))
+(defn run-model
+  "optionals args are filename for csv with settings to modify"
+  ([iterations output? transition-modifier file]
+   (set! *print-length* nil)
+   (let [file-input    (if (nil? file)
+                         (test-inputs)
+                         (assoc (test-inputs) :settings-to-change [(str "data/" inputs-path file) sc/SettingsToChange]))
+         fixed-catalog (let [prep-catalog (->> (:catalog m/send-model)
+                                               (mapv #(if (= (:witan/type %) :input)
+                                                        (add-input-params file-input %)
+                                                        (assoc-in % [:witan/params :simulations] iterations)))
+                                               (map #(assoc-in % [:witan/params :output] output?)))]
+                         (if (nil? transition-modifier)
+                           prep-catalog
+                           (map #(assoc-in % [:witan/params :modify-transition-by] transition-modifier) prep-catalog)))
+         workspace     {:workflow  (:workflow m/send-model)
+                        :catalog   fixed-catalog
+                        :contracts (p/available-fns (m/model-library))}
+         workspace'    (s/with-fn-validation (wex/build! workspace))
+         result        (apply merge (wex/run!! workspace' {}))]
+     (set! *print-length* 200)))
+  ([iterations output?]
+   (run-model iterations output? nil nil)))

--- a/test/witan/send/acceptance/workspace_test.clj
+++ b/test/witan/send/acceptance/workspace_test.clj
@@ -30,7 +30,7 @@
   (testing "The default model is run on the workspace and returns the outputs expected"
     (let [fixed-catalog (->> (:catalog m/send-model)
                              (mapv #(if (= (:witan/type %) :input)
-                                      (add-input-params %)
+                                      (add-input-params (test-inputs) %)
                                       (assoc-in % [:witan/params :simulations] 10)))
                              (map #(assoc-in % [:witan/params :output] false)))
           workspace     {:workflow  (:workflow m/send-model)

--- a/test/witan/send/acceptance/workspace_test.clj
+++ b/test/witan/send/acceptance/workspace_test.clj
@@ -12,7 +12,8 @@
 (def inputs-path "demo/")
 
 (defn test-inputs []
-  {:initial-send-population [(str "data/" inputs-path "send-population.csv") sc/SENDPopulation]
+  {:settings-to-change ["data/demo/modify-settings.csv" sc/SettingsToChange]
+   :initial-send-population [(str "data/" inputs-path "send-population.csv") sc/SENDPopulation]
    :transition-matrix [(str "data/" inputs-path "transitions.csv") sc/TransitionCounts]
    :population [(str "data/" inputs-path "population.csv") sc/PopulationDataset]
    :setting-cost [(str "data/" inputs-path "need-setting-costs.csv") sc/NeedSettingCost]

--- a/test/witan/send/send_test.clj
+++ b/test/witan/send/send_test.clj
@@ -176,10 +176,26 @@
     (testing "all vals are numbers"
       (is (every? #(number? %) (reduce concat result))))))
 
-(deftest modify-transition-count-test
-  (testing ""
-    (is (= 2 (get (modify-transition-count {[2014 1 :NONSEND :SEMH-MMSIB] 1 [2014 1 :NONSEND :CL-MMSIB] 4} [2014 1 :NONSEND :SEMH-MMSIB] * 2) [2014 1 :NONSEND :SEMH-MMSIB])))))
+(deftest modify-transitions-test
+  (let [transitions {[2014 1 :NONSEND :SEMH-MMSIB] 2, [2014 1 :NONSEND :SP-MMSIB] 3, [2014 1 :SP-MU :SP-MU] 2}
+        state-change1 [[2014 1 :SP-MU :SP-MU] [2014 1 :NONSEND :SEMH-MMSIB]]
+        state-change2 [[2014 1 :NONSEND :SP-MMSIB] [2014 1 :NONSEND :SEMH-MMSIB]]]
+    (testing "modifies transitions"
+      (is (not= transitions (modify-transitions transitions state-change1 * 0.5))))
+    (testing "state [2014 8 :SP-MU :SP-MU] is divided by two"
+      (is (= 1 (get (modify-transitions transitions state-change1 * 0.5) [2014 1 :SP-MU :SP-MU]))))
+    (testing "state [2014 0 :NONSEND :SP-MMSIB] takes the joiners of state [2014 8 :SP-MU :SP-MU]"
+      (is (= 3 (get (modify-transitions transitions state-change1 * 0.5) [2014 1 :NONSEND :SEMH-MMSIB]))))
+    (testing "odd values are rounded and exchanged correctly"
+      (is (= 3 (get (modify-transitions transitions state-change2 * 0.5) [2014 1 :NONSEND :SEMH-MMSIB])))
+      (is (= 2 (get (modify-transitions transitions state-change2 * 0.5) [2014 1 :NONSEND :SP-MMSIB]))))))
 
 (deftest transition-present?-test
-  (testing ""
+  (testing "transition state is present in coll"
     (is (transition-present? [11 :CI-MSSOB :CI-ISSR] '([6 :OTH-MSSSH :OTH-MSSSH] [6 :SP-MU :SP-MU] [6 :UKN-MMSIB :UKN-MMSIB] [11 :CI-MSSOB :CI-ISSR] [6 :SP-IMS :SP-IMS] [6 :SEMH-MSSCT :SEMH-NMSS] [8 :CI-OOE :CI-ISS] [8 :CI-MMSOB :CI-MMSOB] [6 :SP-MU :SP-NMSS] [6 :CI-MSSSH :CI-MSSSH] [8 :SEMH-MMSIB :NONSEND] [13 :SP-MSSOB :NONSEND] [4 :CL-MSSSH :NONSEND])))))
+
+(deftest update-ifelse-assoc-test
+  (testing "if key present +1 to val"
+    (is (= 2 (:foo (update-ifelse-assoc {:foo 1 :bar 2} :foo + 1)))))
+  (testing "if key not present, insert key with val"
+    (is (= 1 (:foo (update-ifelse-assoc {:baz 1 :bar 2} :foo + 1))))))


### PR DESCRIPTION
Take the removed joiners from specific states and apply them elsewhere so the same overall joiner rate is maintained. Where to redistribute these joiners is now provided as an additional optional input file.

Run-model is now multi-arity able to take the "default" two arguments or additional two more, allowing a modification the joiner rate of settings specified in a new input file