### PR TITLE
Refactor build-states-to-change

### DIFF
--- a/src/clj/witan/send/model.clj
+++ b/src/clj/witan/send/model.clj
@@ -52,7 +52,8 @@
     :witan/version "1.0.0"
     :witan/type :function
     :witan/fn :send/prepare-send-inputs
-    :witan/params {:modify-transition-by 1
+    :witan/params {:which-transitions? nil
+                   :modify-transition-by 1
                    :splice-ncy nil
                    :filter-transitions-from nil}}
    {:witan/name :run-send-model

--- a/src/clj/witan/send/schemas.clj
+++ b/src/clj/witan/send/schemas.clj
@@ -202,3 +202,6 @@
    :setting-cost-lookup SettingCostLookup
    :valid-setting-academic-years ValidSettingAcademicYears
    :transition-matrix TransitionCounts})
+
+(def transition-type
+  (s/maybe [s/Str]))

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -279,20 +279,19 @@
                                            :setting-2))
                              (map #(vector (:setting-1 %)) to-maps)
                              (map #(vector (:setting-1 %) (:setting-2 %)) to-maps))]
-    (->> (mapcat (fn [year]
-                   (mapcat (fn [age]
-                             (mapcat (fn [need]
-                                       (mapcat (fn [setting]
-                                                 (map (fn [setting-to-change]
-                                                        (let [keys {:transition-type transition-type :cy year :ay age
-                                                                    :need need :move-state (states/state need setting)}]
-                                                          (if (= :nil (-> to-maps
-                                                                          first
-                                                                          :setting-2))
-                                                            (vector (generate-transition-key (merge keys {:setting (first setting-to-change)})))
-                                                            (vector (generate-transition-key (merge keys {:setting (first setting-to-change)}))
-                                                                    (generate-transition-key (merge keys {:setting (second setting-to-change)}))))))
-                                                      settings-to-change)) valid-settings)) valid-needs)) ages)) years)
+    (->> (for [year years
+               age ages
+               need valid-needs
+               setting valid-settings
+               setting-to-change settings-to-change]
+           (let [keys {:transition-type transition-type :cy year :ay age
+                       :need need :move-state (states/state need setting)}]
+             (if (= :nil (-> to-maps
+                             first
+                             :setting-2))
+               (vector (generate-transition-key (merge keys {:setting (first setting-to-change)})))
+               (vector (generate-transition-key (merge keys {:setting (first setting-to-change)}))
+                       (generate-transition-key (merge keys {:setting (second setting-to-change)}))))))
          (remove #(nil? (first %)))
          distinct)))
 

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -273,8 +273,7 @@
               :mover-state-alphas  (p/alpha-params-movers valid-states valid-transitions transition-matrix)}))))
 
 (defn build-states-to-change [input valid-needs valid-settings ages years transition-type]
-  (let [to-maps (->> input
-                     ds/row-maps)
+  (let [to-maps (ds/row-maps input)
         settings-to-change (if (= :nil (-> to-maps
                                            first
                                            :setting-2))
@@ -294,7 +293,6 @@
                                                             (vector (generate-transition-key (merge keys {:setting (first setting-to-change)}))
                                                                     (generate-transition-key (merge keys {:setting (second setting-to-change)}))))))
                                                       settings-to-change)) valid-settings)) valid-needs)) ages)) years)
-         vec
          (remove #(nil? (first %)))
          distinct)))
 

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -199,17 +199,18 @@
 
 (defn generate-transition-key [{:keys [transition-type cy ay need setting move-state]}]
   (when (not= move-state (states/state need setting))
-    (cond (= transition-type "joiners")
-          (vector cy ay :NONSEND (states/state need setting))
+    (case transition-type
+      "joiners"
+      (vector cy ay :NONSEND (states/state need setting))
 
-          (= transition-type "leavers")
-          (vector cy ay (states/state need setting) :NONSEND)
+      "leavers"
+      (vector cy ay (states/state need setting) :NONSEND)
 
-          (= transition-type "movers-to")
-          (vector cy ay move-state (states/state need setting))
+      "movers-to"
+      (vector cy ay move-state (states/state need setting))
 
-          (= transition-type "movers-from")
-          (vector cy ay (states/state need setting) move-state))))
+      "movers-from"
+      (vector cy ay (states/state need setting) move-state))))
 
 (defn update-ifelse-assoc [m k arithmetic-fn v]
   (if (contains? m k)

--- a/test/witan/send/acceptance/workspace_test.clj
+++ b/test/witan/send/acceptance/workspace_test.clj
@@ -55,12 +55,16 @@
 
   :transitions-file - csv containing list of settings to modify by :transition-modifier (optional)
 
+  :which-transitions? - vector of either one or more transition type strings i.e. \"joiners\", \"movers-tp\",
+  \"movers-from\" or \"leavers\", used in conjunction with :transition-modifier and :transitions-file (optional)
+
   :modify-transitions-from - set a year to start modifying transitions from when :transition-modifier & :transitions-file are set (optional)
 
   :filter-transitions-from - sets a year or year range as a vector to filter historic transitions by for :splice-ncy (optional)
 
   :splice-ncy - sets a national curriculum year to ignore transitions of prior to :filter-transitions-from year (optional)"
-  [{:keys [iterations output? transition-modifier transitions-file modify-transitions-from filter-transitions-from splice-ncy]}]
+  [{:keys [iterations output? transition-modifier transitions-file which-transitions?
+           modify-transitions-from filter-transitions-from splice-ncy]}]
   (report/reset-send-report)
   (report/info "Input Data: " (report/bold (str/replace (str/join "" (drop-last inputs-path)) #"/" " ")))
   (report/info "Number of iterations: " (report/bold iterations))
@@ -80,7 +84,9 @@
                                                (map #(assoc-in % [:witan/params :output] output?)))
                             prep-catalog2 (if (nil? transition-modifier)
                                             prep-catalog1
-                                            (map #(assoc-in % [:witan/params :modify-transition-by] transition-modifier) prep-catalog1))
+                                            (->> prep-catalog1
+                                                 (map #(assoc-in % [:witan/params :modify-transition-by] transition-modifier))
+                                                 (map #(assoc-in % [:witan/params :which-transitions?] which-transitions?))))
                             prep-catalog3 (if (nil? modify-transitions-from)
                                             prep-catalog2
                                             (map #(assoc-in % [:witan/params :modify-transitions-from] modify-transitions-from) prep-catalog2))]

--- a/test/witan/send/acceptance/workspace_test.clj
+++ b/test/witan/send/acceptance/workspace_test.clj
@@ -55,7 +55,7 @@
 
   :transitions-file - csv containing list of settings to modify by :transition-modifier (optional)
 
-  :which-transitions? - vector of either one or more transition type strings i.e. \"joiners\", \"movers-tp\",
+  :which-transitions? - vector of either one or more transition type strings i.e. \"joiners\", \"movers-to\",
   \"movers-from\" or \"leavers\", used in conjunction with :transition-modifier and :transitions-file (optional)
 
   :modify-transitions-from - set a year to start modifying transitions from when :transition-modifier & :transitions-file are set (optional)
@@ -69,6 +69,7 @@
   (report/info "Input Data: " (report/bold (str/replace (str/join "" (drop-last inputs-path)) #"/" " ")))
   (report/info "Number of iterations: " (report/bold iterations))
   (report/info "Output charts produced: " (report/bold output?))
+  (report/info "Modifying " (report/bold (if (nil? which-transitions?) "None" (str/join ", " which-transitions?))))
   (report/info "Transitions modifier: " (report/bold (if (nil? transition-modifier) "None" transition-modifier)))
   (report/info "Transitions file: " (report/bold (if (nil? transitions-file) "None" transitions-file)))
   (report/info "Modify transitions from: " (report/bold (if (nil? modify-transitions-from) "None" modify-transitions-from)))


### PR DESCRIPTION
Allow modify transitions to apply to any kind of transition (joiner, mover or leaver)