### PR TITLE
Feature/validate

### DIFF
--- a/src/clj/witan/send/validate_model.clj
+++ b/src/clj/witan/send/validate_model.clj
@@ -1,0 +1,76 @@
+(ns witan.send.validate-model
+  (:require [witan.send.test-utils :as tu]
+            [clojure.data.csv :as csv]
+            [clojure.java.io :as io]))
+
+
+
+;; get files to validate on
+
+
+;;; write validations dir
+
+(defn csv-data->maps [csv-data]
+  (map zipmap
+       (->> (first csv-data)
+            (map keyword)
+            repeat)
+       (rest csv-data)))
+
+(defn write-csv [transitions path]
+  (with-open [writer (io/writer (io/file path))]
+    (let [columns (into [] (keys (first transitions)))
+          headers (mapv name columns)
+          rows (mapv #(mapv % columns) transitions)]
+    (csv/write-csv writer (into [headers] rows)))))
+
+(defn load-transitions [path]
+  (csv-data->maps
+    (with-open [reader (io/reader (str "data/" path "transitions.csv"))]
+      (doall
+        (csv/read-csv reader)))))
+
+(defn get-unique-years [transitions]
+  (->> (map :calendar-year transitions)
+       (distinct)
+       (map #(Integer/parseInt %))))
+
+
+(defn return-up-to-fold [year-limit transitions]
+  (filter #(<= (Integer/parseInt (:calendar-year %)) year-limit) transitions))
+
+(defn return-after-fold [year-limit transitions]
+  (filter #(> (Integer/parseInt (:calendar-year %)) year-limit) transitions))
+
+
+
+
+
+(defn split-and-test [year transitions]
+  (let [train (return-up-to-fold year transitions)
+        test (return-after-fold year transitions)]
+    (write-csv test (str "validate/test" year ".csv"))))
+
+
+
+;;for each year
+  ;; train = split up to fold
+  ;; test = split after fold
+  ;; write test to csv
+  ;; run model with csvs
+  ;; store results
+
+(defn split-into-folds [transitions]
+  (let [years (get-unique-years transitions)]))
+
+
+
+
+
+
+;; split files into folds
+
+;; run model with individual folds
+  ;; shuttle results into unqiue folders
+
+;; colate results

--- a/src/clj/witan/send/validate_model.clj
+++ b/src/clj/witan/send/validate_model.clj
@@ -1,14 +1,16 @@
 (ns witan.send.validate-model
   (:require [witan.send.test-utils :as tu]
             [clojure.data.csv :as csv]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [witan.send.acceptance.workspace-test :refer [run-model]]))
 
 
 
-;; get files to validate on
-
-
+; TODOs
+;; setup function:
 ;;; write validations dir
+;;; write path/temp dir
+
 
 (defn csv-data->maps [csv-data]
   (map zipmap
@@ -30,26 +32,51 @@
       (doall
         (csv/read-csv reader)))))
 
-(defn get-unique-years [transitions]
+(defn get-validation-years [transitions]
   (->> (map :calendar-year transitions)
        (distinct)
-       (map #(Integer/parseInt %))))
+       (map #(Integer/parseInt %))
+       (drop-last)))
+
+(defn return-fold [bound year transitions]
+  (filter #(bound (Integer/parseInt (:calendar-year %)) year) transitions))
+
+(defn copy-if-exists [source-path destination-path file]
+  (let [source (str source-path file)]
+    (if (.exists (clojure.java.io/as-file source))
+      (io/copy (io/file source) (io/file (str destination-path file))))))
+
+(defn copy-input-files [input-path year]
+  (let [source-path (str "data/" input-path)
+        destination-path (str source-path "temp/" year "/")]
+    (.mkdir (java.io.File. destination-path))
+    (doseq [file ["modify-settings.csv" "population.csv" "need-setting-costs.csv" "valid-setting-academic-years.csv"]]
+      (copy-if-exists source-path destination-path file))))
+
+(defn move-target-files [year]
+  (doseq [file ["Output_Count.csv" "Output_AY_State.csv"]]
+    (io/copy (io/file (str "target/" file)) (io/file (str "validation/" year "_modelled_" file)))))
 
 
-(defn return-up-to-fold [year-limit transitions]
-  (filter #(<= (Integer/parseInt (:calendar-year %)) year-limit) transitions))
+(defn validate-fold [input-path year transitions settings]
+  (if (contains? settings :override-inputs-path)
+    (throw (IllegalArgumentException. "Overriding inputs will break model validation")))
+  (let [train (return-fold <= year transitions)
+        test (return-fold > year transitions)
+        train-settings (merge settings {:override-inputs-path (str input-path "temp/" year "/")})]
+    (copy-input-files input-path year)
+    (write-csv train (str "data/" input-path "temp/" year "/transitions.csv"))
+    (write-csv test (str "validation/test_" year ".csv"))
+    (run-model train-settings)
+    (move-target-files year)))
 
-(defn return-after-fold [year-limit transitions]
-  (filter #(> (Integer/parseInt (:calendar-year %)) year-limit) transitions))
 
 
 
 
 
-(defn split-and-test [year transitions]
-  (let [train (return-up-to-fold year transitions)
-        test (return-after-fold year transitions)]
-    (write-csv test (str "validate/test" year ".csv"))))
+;; move files to temp folder
+;; run model with temp files
 
 
 
@@ -60,8 +87,6 @@
   ;; run model with csvs
   ;; store results
 
-(defn split-into-folds [transitions]
-  (let [years (get-unique-years transitions)]))
 
 
 

--- a/src/clj/witan/send/validate_model.clj
+++ b/src/clj/witan/send/validate_model.clj
@@ -1,17 +1,12 @@
 (ns witan.send.validate-model
-  (:require [witan.send.test-utils :as tu]
-            [clojure.data.csv :as csv]
+  (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [witan.send.acceptance.workspace-test :refer [run-model]]))
 
 
-
-; TODOs
-;; setup function:
-;;; write validations dir
-;;; write path/temp dir
-
+(defn temp-dir [input-path]
+  (str "data/" input-path "temp/"))
 
 (defn csv-data->maps [csv-data]
   (map zipmap
@@ -20,18 +15,12 @@
             repeat)
        (rest csv-data)))
 
-(defn write-csv [data path]
-  (with-open [writer (io/writer (io/file path))]
+(defn write-csv [file data]
+  (with-open [writer (io/writer (io/file file))]
     (let [columns (into [] (keys (first data)))
           headers (mapv name columns)
           rows (mapv #(mapv % columns) data)]
     (csv/write-csv writer (into [headers] rows)))))
-
-(defn load-transitions [path]
-  (csv-data->maps
-    (with-open [reader (io/reader (str "data/" path "transitions.csv"))]
-      (doall
-        (csv/read-csv reader)))))
 
 (defn load-csv-as-maps [file]
   (csv-data->maps
@@ -45,8 +34,8 @@
        (map #(Integer/parseInt %))
        (drop-last)))
 
-(defn return-fold [bound year transitions]
-  (filter #(bound (Integer/parseInt (:calendar-year %)) year) transitions))
+(defn return-fold [bound-fn year transitions]
+  (filter #(bound-fn (Integer/parseInt (:calendar-year %)) year) transitions))
 
 (defn copy-if-exists [source-path destination-path file]
   (let [source (str source-path file)]
@@ -55,101 +44,83 @@
 
 (defn copy-input-files [input-path year]
   (let [source-path (str "data/" input-path)
-        destination-path (str source-path "temp/" year "/")]
+        destination-path (str (temp-dir input-path) year "/")]
     (.mkdir (java.io.File. destination-path))
     (doseq [file ["modify-settings.csv" "population.csv" "need-setting-costs.csv" "valid-setting-academic-years.csv"]]
       (copy-if-exists source-path destination-path file))))
 
-(defn move-target-files [year]
+(defn move-target-files [input-path year]
   (doseq [file ["Output_Count.csv" "Output_AY_State.csv"]]
-    (io/copy (io/file (str "target/" file)) (io/file (str "validation/model_" year "_" file)))))
+    (io/copy (io/file (str "target/" file)) (io/file (str (temp-dir input-path) year "_" file)))))
 
 (defn return-testable-data [file test-years]
   (->> (for [year test-years] (filter #(= year (:calendar-year %)) (load-csv-as-maps file)))
        (mapcat seq)))
 
-(defn append-count-with-test [model-count test-data]
+(defn append-count-with-test [model-count test-data n-transitions]
   (let [test-year (str (dec (Integer/parseInt (:calendar-year model-count))))
         test-data-for-year  (filter #(= test-year (:calendar-year %)) test-data)
         send-test-data-for-year  (filter #(not= "NONSEND" (:need-2 %)) test-data-for-year)
         ground-truth-count (count send-test-data-for-year)]
-    (assoc model-count :ground-truth (str ground-truth-count))))
+    (assoc model-count :ground-truth (str ground-truth-count) :n-transition n-transitions)))
 
-(defn append-state-with-test [model-state test-data]
+(defn append-state-with-test [model-state test-data n-transitions]
   (let [test-year (str (dec (Integer/parseInt (:calendar-year model-state))))
         state-vector (str/split (str/replace (:state model-state) ":" "") #"-")
         need (first state-vector)
         setting (last state-vector)
         academic-year (:academic-year model-state)
         test-data-for-state (filter #(and (= test-year (:calendar-year %))
-                                         (= need (:need-2 %))
-                                         (= setting (:setting-2 %))
-                                         (= academic-year (:academic-year-2 %))) test-data)
+                                          (= need (:need-2 %))
+                                          (= setting (:setting-2 %))
+                                          (= academic-year (:academic-year-2 %))) test-data)
         ground-truth-count (count test-data-for-state)]
-    (assoc model-state :ground-truth (str ground-truth-count))))
+    (assoc model-state :ground-truth (str ground-truth-count) :n-transitions (str n-transitions))))
 
-
-(defn append-model-with-test-data [model-data test-data filter-function  ])
-
-(defn collate-fold [year]
-  (let [test (load-csv-as-maps (str "validation/test_" year ".csv"))
-
-        ;;test-years (distinct (map :calendar-year test))
-        test-years (->> (map :calendar-year test)
+(defn collate-fold [input-path year n-transitions]
+  (let [test-data (load-csv-as-maps (str (temp-dir input-path) "test_" year ".csv"))
+        test-years (->> (map :calendar-year test-data)
                         (distinct)
                         (map #(inc (Integer/parseInt %)))
                         (into [])
                         (map str))
-        model-state (return-testable-data (str "validation/model_" year "_Output_AY_State.csv") test-years)
-        model-count (return-testable-data (str "validation/model_" year "_Output_Count.csv") test-years)
-        count-results (map #(append-count-with-test % test) model-count)
-        state-results (map #(append-state-with-test % test) model-state)]
-    ;; for each distinct year: get count of non-send
-    (def t test)
-    (def ty test-years)
-    (def ms model-state)
-    (def mc model-count)
-    (def cr count-results)
-    (write-csv count-results (str "validation/results_" year "_count.csv"))
-    (write-csv state-results (str "validation/results_" year "_state.csv"))))
+        model-state (return-testable-data (str (temp-dir input-path) year "_Output_AY_State.csv") test-years)
+        model-count (return-testable-data (str (temp-dir input-path) year "_Output_Count.csv") test-years)
+        count-results (map #(append-count-with-test % test-data n-transitions) model-count)
+        state-results (map #(append-state-with-test % test-data n-transitions) model-state)]
+    (write-csv (str (temp-dir input-path) "results_" year "_count.csv") count-results)
+    (write-csv (str (temp-dir input-path) "results_" year "_state.csv") state-results)))
 
 (defn validate-fold [input-path year transitions settings]
-  (let [train (return-fold <= year transitions)
-        test (return-fold > year transitions)
-        train-settings (merge settings {:output? true :override-inputs-path (str input-path "temp/" year "/")})]
+  (def temp (temp-dir input-path))
+  (let [train-data (return-fold <= year transitions)
+        n-transitions (count (distinct (map :calendar-year train-data)))
+        test-data (return-fold > year transitions)
+        fold-settings (merge settings {:output? true :override-inputs-path (str input-path "temp/" year "/")})]
     (copy-input-files input-path year)
-    (write-csv train (str "data/" input-path "temp/" year "/transitions.csv"))
-    (write-csv test (str "validation/test_" year ".csv"))
-    (run-model train-settings)
-    (move-target-files year)
-    (collate-fold year)))
+    (write-csv (str (temp-dir input-path) year "/transitions.csv") train-data)
+    (write-csv (str (temp-dir input-path) "test_" year ".csv") test-data)
+    (run-model fold-settings)
+    (move-target-files input-path year)
+    (collate-fold input-path year n-transitions)))
 
-
-
-
-
-
-;; move files to temp folder
-;; run model with temp files
-
-
-
-;;for each year
-  ;; train = split up to fold
-  ;; test = split after fold
-  ;; write test to csv
-  ;; run model with csvs
-  ;; store results
-
-
-
-
-
-
-
-;; split files into folds
-
-;; run model with individual folds
-  ;; shuttle results into unqiue folders
-
-;; colate results
+(defn run-validation [input-path settings-map keep-temp-files?]
+  "Function to validate SEND model.
+  input-path is a string with the data directory to validate the model on e.g. demo/
+  settings-map expects a hash map containing run-model parameters to use for validation eg. {:iterations 100}
+  (note that run-model's :output? and :override-inputs-path arguments are both required for validation and are overwritten if provided)
+  keep-temp-files? can be set to false unless debugging etc."
+  (.mkdir (java.io.File. (temp-dir input-path)))
+  (let [transitions (load-csv-as-maps (str "data/" input-path "transitions.csv"))
+        years-to-validate (get-validation-years transitions)]
+    (doseq [year years-to-validate]
+      (validate-fold input-path year transitions settings-map))
+    (->> (map #(load-csv-as-maps (str "data/demo/temp/results_" % "_count.csv")) years-to-validate)
+         (flatten)
+         (write-csv (str "validation_result_count_" (str/join (drop-last input-path)) ".csv")))
+    (->> (map #(load-csv-as-maps (str "data/demo/temp/results_" % "_state.csv")) years-to-validate)
+         (flatten)
+         (write-csv (str "validation_result_state_" (str/join (drop-last input-path)) ".csv"))))
+  (if (false? keep-temp-files?)
+    (doseq [file (reverse (file-seq (io/file (temp-dir input-path))))]
+      (io/delete-file file))))


### PR DESCRIPTION
This implements the forward chaining validation workflow for send (outlined here: https://witanblog.wordpress.com/2018/01/09/roadmap-for-implementing-send-validation/#comment-1284)

 - Each year of input data is split into separate "folds" which contain the data up to and including that year. 
- The model is run on each individual fold of input data and the results are moved into a temp dir
- The "ground truth" is added to the model predictions, and then the predictions are combined into a single csv.
