### PR TITLE
Highlight available tooling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,13 @@ and  run automatically. This would be useful, for example, if you wanted to comp
 for many different alternative scenario parameters. Example input for the main `run-multi-configs` 
 function are given in the NS.
 
+## Tools
  
+ In `utils` you will find tools for preparing a a valid states file purely from a transitions file and for making comparative plots for total count and cost for alternative runs of the model.
 
 ## License
 
-Copyright © 2017 MastodonC Ltd
+Copyright © 2018 MastodonC Ltd
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ function are given in the NS.
 
 ## Tools
  
- In `utils` you will find tools for preparing a a valid states file purely from a transitions file and for making comparative plots for total count and cost for alternative runs of the model.
+ In `utils` you will find tools for preparing a a valid states file purely from a transitions file and for making comparative plots between total count and cost for alternative runs of the model.
 
 ## License
 


### PR DESCRIPTION
There are a number of tools external to the model, which need to be highlighted for future use