### PR TITLE
Tidy up main and multi-config

### DIFF
--- a/src/clj/witan/send/main.clj
+++ b/src/clj/witan/send/main.clj
@@ -57,8 +57,9 @@
 
 (defn run-recorded-send [config]
   (let [metadata (md/metadata config)]
-    (-> (send/run-send-workflow config)
-        (so/output-send-results (:output-parameters config)))
+    (so/output-send-results
+     (send/run-send-workflow config)
+     (:output-parameters config))
     (when (get-in config [:validation-parameters :run-as-default])
       (vm/run-send-validation config))
     (save-runtime-config config)

--- a/src/clj/witan/send/main.clj
+++ b/src/clj/witan/send/main.clj
@@ -1,14 +1,13 @@
 (ns witan.send.main
-  (:require [schema.core :as s]
-            [witan.send.send :as send]
+  (:gen-class)
+  (:require [aero.core :as aero]
+            [clojure.pprint :refer [pprint]]
+            [clojure.string :as string]
+            [witan.send.metadata :as md]
             [witan.send.model.output :as so]
             [witan.send.schemas :as sc]
-            [aero.core :refer [read-config]]
-            [clojure.string :refer [join]]
-            [clojure.pprint :refer [pprint]]
-            [witan.send.metadata :as md]
-            [witan.send.validate-model :as vm])
-  (:gen-class))
+            [witan.send.send :as send]
+            [witan.send.validate-model :as vm]))
 
 (defn config [config-path]
   "Read a config file and merge it with schema inputs"
@@ -24,12 +23,12 @@
               {:output-parameters {:project-dir project-dir}})))
 
 (defn get-output-dir [config]
-  (join "/" [(config :project-dir)
-             (get-in config [:output-parameters :output-dir])]))
+  (string/join "/" [(:project-dir config)
+                    (get-in config [:output-parameters :output-dir])]))
 
 (defn save-runtime-config
   [config]
-  (spit (join "/" [(get-output-dir config) "runtime-config.edn"])
+  (spit (string/join "/" [(get-output-dir config) "runtime-config.edn"])
         (with-out-str
           (pprint (-> config
                       (dissoc :schema-inputs)
@@ -37,7 +36,7 @@
 
 (defn save-runtime-metadata
   [config metadata]
-  (spit (join "/" [(get-output-dir config) "runtime-metadata.edn"])
+  (spit (string/join "/" [(get-output-dir config) "runtime-metadata.edn"])
         (with-out-str
           (pprint (md/merge-end-time metadata)))))
 

--- a/src/clj/witan/send/metadata.clj
+++ b/src/clj/witan/send/metadata.clj
@@ -1,10 +1,10 @@
 (ns witan.send.metadata
-  (:require [clj-time.format :as f]
-            [clj-time.core :as t]
+  (:require [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clojure.java.io :as io]
             [clojure.java.shell :as sh]
             [clojure.string :as str]
-            [digest]
-            [clojure.java.io :as io]))
+            digest))
 
 (defn environment-metadata
   []

--- a/src/clj/witan/send/multi_config.clj
+++ b/src/clj/witan/send/multi_config.clj
@@ -1,5 +1,6 @@
 (ns witan.send.multi-config
   (:require [clojure.math.combinatorics :as combo]
+            [clojure.string :as string]
             [witan.send.main :as main]))
 
 (def default-config
@@ -37,7 +38,7 @@
   [combo]
   (conj [:output-parameters :output-dir]
         (-> (apply str (doall (map #(take-last 2 %) combo)))
-            (clojure.string/replace #"[(): ]" ""))))
+            (string/replace #"[(): ]" ""))))
 
 (defn generate-params
   "Generates combinations of input parameters based on input vectors"

--- a/src/clj/witan/send/multi_config.clj
+++ b/src/clj/witan/send/multi_config.clj
@@ -37,8 +37,10 @@
   "Adds unique output-dir val to combination map for given combination of parameters"
   [combo]
   (conj [:output-parameters :output-dir]
-        (-> (apply str (doall (map #(take-last 2 %) combo)))
-            (string/replace #"[(): ]" ""))))
+        (string/replace
+         (string/join (doall (map #(take-last 2 %) combo)))
+         #"[(): ]"
+         "")))
 
 (defn generate-params
   "Generates combinations of input parameters based on input vectors"

--- a/src/clj/witan/send/multi_config.clj
+++ b/src/clj/witan/send/multi_config.clj
@@ -1,9 +1,6 @@
 (ns witan.send.multi-config
-  (:require [witan.send.schemas :as sc]
-            [witan.send.main :as main]
-            [witan.send.send :as send]
-            [witan.send.model.output :as si]
-            [clojure.math.combinatorics :as combo]))
+  (:require [clojure.math.combinatorics :as combo]
+            [witan.send.main :as main]))
 
 (def default-config
   "Static settings for all runs with different configs (settings in inputs will be overwritten)"
@@ -30,27 +27,31 @@
   [[[:run-parameters :random-seed] [1 42]]
    [[:run-parameters :simulations] [10 20 30]]])
 
-(defn generate-param-options [param-name-vec values-vec]
+(defn generate-param-options
   "Takes two vecs and returns form required for combo/cartesian-product"
+  [param-name-vec values-vec]
   (mapv #(conj param-name-vec %) values-vec))
 
-(defn name-output-dir [combo]
+(defn name-output-dir
   "Adds unique output-dir val to combination map for given combination of parameters"
+  [combo]
   (conj [:output-parameters :output-dir]
         (-> (apply str (doall (map #(take-last 2 %) combo)))
             (clojure.string/replace #"[(): ]" ""))))
 
-(defn generate-params [inputs]
+(defn generate-params
   "Generates combinations of input parameters based on input vectors"
+  [inputs]
   (let [param-value-pairs (map #(generate-param-options (first %) (last %)) inputs)
         combos (apply combo/cartesian-product param-value-pairs)]
     (map #(conj % (name-output-dir %)) combos)))
 
-(defn update-nested-map [acc n]
+(defn update-nested-map
   "Helper fn to update nested hashmap given vector output of generate-params"
+  [acc n]
   (assoc-in acc (subvec n 0 (dec (count n))) (last n)))
 
-(defn run-multi-configs [inputs project-dir]
+(defn run-multi-configs
   "Main function to run multi configs. Edit default-config to specify consistent config settings.
 
   Args:
@@ -58,17 +59,11 @@
     project-dir: full path to project (dir which contains file-inputs in default-config)
 
   Returns nil. Model results for each run are output to unique folder in project-dir."
-
+  [inputs project-dir]
   (let [configs (->> (generate-params inputs)
                      (map #(reduce update-nested-map default-config %))
                      (map #(merge-with merge %
-                      {:schema-inputs {:settings-to-change sc/SettingsToChange
-                                       :transition-matrix sc/TransitionCounts
-                                       :population sc/PopulationDataset
-                                       :setting-cost sc/NeedSettingCost
-                                       :valid-setting-academic-years sc/ValidSettingAcademicYears}}
-                      {:project-dir project-dir}
-                      {:output-parameters {:project-dir project-dir}})))]
-    (map #(do (-> (main/run-send %)
-                  (si/output-send-results (:output-parameters %)))
-              (main/save-runtime-config %)) configs)))
+                                       main/default-schemas
+                                       {:project-dir project-dir}
+                                       {:output-parameters {:project-dir project-dir}})))]
+    (map main/run-recorded-send configs)))

--- a/test/witan/send/acceptance/model_test.clj
+++ b/test/witan/send/acceptance/model_test.clj
@@ -1,10 +1,11 @@
 (ns witan.send.acceptance.model-test
-  (:require [clojure.test :refer :all]
-            [witan.send.send :as send]
-            [witan.send.model.output :as so]
-            [witan.send.main :as m]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.string :refer [join]]
+            [clojure.test :refer [deftest is testing]]
+            digest
+            [witan.send.main :as m]
+            [witan.send.model.output :as so]
+            [witan.send.send :as send]
             [witan.send.validate-model :as v]))
 
 (deftest expected-results
@@ -25,7 +26,7 @@
                              (map #(str "Historic_Transitions_" % ".pdf") historic-years))
         files (keys expected-md5s)
         files-and-plots (into expected-plots files)
-        config (m/config "data/demo/config.edn")
+        config (m/read-config "data/demo/config.edn")
         output-dir (m/get-output-dir config)]
     (run! #(let [file (join "/" [output-dir %])]
              (when (.exists (io/file file))

--- a/test/witan/send/acceptance/validate_model_test.clj
+++ b/test/witan/send/acceptance/validate_model_test.clj
@@ -2,15 +2,15 @@
   (:require [clojure.java.io :as io]
             [clojure.string :refer [join]]
             [clojure.test :refer [deftest is testing]]
+            digest
             [witan.send.main :as m]
-            [witan.send.validate-model :as vm]
-            [digest]))
+            [witan.send.validate-model :as vm]))
 
 (deftest expected-validation-results
   (let [expected-md5s {"validation_results_count.csv" "0c23282d207431a438fd1a5a94049d9c",
                        "validation_results_state.csv" "e58fe1fe2c6b6bc75866f41a367564b1"}
         files (keys expected-md5s)
-        config (m/config "data/demo/config.edn")
+        config (m/read-config "data/demo/config.edn")
         validation-dir (join "/" [(:project-dir config) "validation"])]
     (run! #(let [file (join "/" [validation-dir %])]
              (when (.exists (io/file file))


### PR DESCRIPTION
There were too many dependencies between multi-config and other namespaces and some of the recording methods were getting out of step too. This is to avoid unnecessary repetition and tidy some things up along the way.