### PR TITLE
Remove some duplicate definitions

### DIFF
--- a/src/clj/witan/send/constants.clj
+++ b/src/clj/witan/send/constants.clj
@@ -1,5 +1,7 @@
 (ns witan.send.constants)
 
+(def non-send :NONSEND)
+
 (def academic-years
   (range -4 (inc 21)))
 

--- a/src/clj/witan/send/maths.clj
+++ b/src/clj/witan/send/maths.clj
@@ -1,0 +1,8 @@
+(ns witan.send.maths)
+
+(def some+
+  "x + y. Returns y if x is nil and x if y is nil."
+  (fnil + 0))
+
+(defn round [x]
+  (Double/parseDouble (format "%.02f" (double x))))

--- a/src/clj/witan/send/maths.clj
+++ b/src/clj/witan/send/maths.clj
@@ -4,5 +4,7 @@
   "x + y. Returns y if x is nil and x if y is nil."
   (fnil + 0))
 
-(defn round [x]
+(defn round
+  "This rounds numbers to 2 decimal places."
+  [x]
   (Double/parseDouble (format "%.02f" (double x))))

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -1,6 +1,7 @@
 (ns witan.send.model.run
   (:require [clojure.core.matrix.dataset :as ds]
             [redux.core :as r]
+            [witan.send.constants :as c]
             [witan.send.distributions :as d]
             [witan.send.maths :as m]
             [witan.send.schemas :as sc]
@@ -55,7 +56,7 @@
                                {state (- population l)})
           [model transitions] (incorporate-new-states-for-academic-year-state [model transitions] year state next-states-sample calendar-year)]
       [model
-       (update transitions [calendar-year year state sc/non-send] m/some+ l)])
+       (update transitions [calendar-year year state c/non-send] m/some+ l)])
     [model transitions]))
 
 (defn apply-leavers-movers-for-cohort
@@ -66,14 +67,14 @@
    [[year state] population :as cohort]
    params calendar-year]
   (cond
-    (= state sc/non-send)
+    (= state c/non-send)
     model-state
     (or (<= year sc/min-academic-year)
         (> year sc/max-academic-year))
     [model
      (cond-> transitions
        (pos? population)
-       (update [calendar-year year state sc/non-send] m/some+ population))]
+       (update [calendar-year year state c/non-send] m/some+ population))]
     :else
     (apply-leavers-movers-for-cohort-unsafe model-state cohort params calendar-year)))
 
@@ -87,7 +88,7 @@
         (if (zero? joiners)
           [model transitions]
           (let [joiner-states (d/sample-dirichlet-multinomial joiners alphas)]
-            (incorporate-new-states-for-academic-year-state [model transitions] academic-year sc/non-send joiner-states calendar-year))))
+            (incorporate-new-states-for-academic-year-state [model transitions] academic-year c/non-send joiner-states calendar-year))))
       [model transitions])))
 
 (defn run-model-iteration

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -1,12 +1,12 @@
 (ns witan.send.model.run
-  (:require [witan.send.schemas :as sc]
-            [clojure.core.matrix.dataset :as ds]
-            [witan.send.step :as step]
-            [witan.send.states :as states]
-            [witan.send.utils :as u :refer [round]]
+  (:require [clojure.core.matrix.dataset :as ds]
             [redux.core :as r]
-            [witan.send.report :refer [reset-send-report]]
-            [witan.send.distributions :as d]))
+            [witan.send.distributions :as d]
+            [witan.send.maths :as m]
+            [witan.send.schemas :as sc]
+            [witan.send.states :as states]
+            [witan.send.step :as step]
+            [witan.send.utils :as u]))
 
 (defn incorporate-new-states-for-academic-year-state
   "Take a model + transitions tuple as its first argument.
@@ -16,12 +16,12 @@
    (reduce (fn [coll [next-state n]]
              (cond-> coll
                (pos? n)
-               (update [academic-year next-state] u/some+ n)))
+               (update [academic-year next-state] m/some+ n)))
            model next-states-sample)
    (reduce (fn [coll [next-state n]]
              (cond-> coll
                (pos? n)
-               (update [calendar-year academic-year state next-state] u/some+ n)))
+               (update [calendar-year academic-year state next-state] m/some+ n)))
            transitions next-states-sample)))
 
 (defn sample-send-transitions
@@ -55,7 +55,7 @@
                                {state (- population l)})
           [model transitions] (incorporate-new-states-for-academic-year-state [model transitions] year state next-states-sample calendar-year)]
       [model
-       (update transitions [calendar-year year state sc/non-send] u/some+ l)])
+       (update transitions [calendar-year year state sc/non-send] m/some+ l)])
     [model transitions]))
 
 (defn apply-leavers-movers-for-cohort
@@ -73,7 +73,7 @@
     [model
      (cond-> transitions
        (pos? population)
-       (update [calendar-year year state sc/non-send] u/some+ population))]
+       (update [calendar-year year state sc/non-send] m/some+ population))]
     :else
     (apply-leavers-movers-for-cohort-unsafe model-state cohort params calendar-year)))
 

--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -1,8 +1,7 @@
 (ns witan.send.params
-  (:require [witan.send.states :as s]
+  (:require [witan.send.maths :as m]
+            [witan.send.states :as s]
             [witan.send.utils :as u]))
-
-(def some+ (fnil + 0))
 
 (def natural-prior 1/3)
 
@@ -54,7 +53,7 @@
 
 (defn alpha-params [transitions f]
   (reduce (fn [coll [transition n]]
-            (update-in coll (f transition) some+ n))
+            (update-in coll (f transition) m/some+ n))
           {} transitions))
 
 (defn state-1-setting
@@ -79,8 +78,8 @@
   [transitions f]
   (reduce (fn [coll [[ay _ _ :as transition] n]]
             (if (f transition)
-              (update-in coll [ay :alpha] some+ n)
-              (update-in coll [ay :beta] some+ n)))
+              (update-in coll [ay :alpha] m/some+ n)
+              (update-in coll [ay :beta] m/some+ n)))
           {} transitions))
 
 (defn beta-params-academic-year-setting
@@ -88,8 +87,8 @@
   (reduce (fn [coll [[ay state-1 :as transition] n]]
             (let [[_ setting] (s/need-setting state-1)]
               (if (f transition)
-                (update-in coll [[ay setting] :alpha] some+ n)
-                (update-in coll [[ay setting] :beta] some+ n))))
+                (update-in coll [[ay setting] :alpha] m/some+ n)
+                (update-in coll [[ay setting] :beta] m/some+ n))))
           {} transitions))
 
 (defn weighted-beta-params
@@ -181,8 +180,8 @@
                            p (get-in population [cy ay])]
                        (if j
                          (-> coll
-                             (update-in [ay :alpha] u/some+ (/ j n))
-                             (update-in [ay :beta] u/some+ (/ (- p j) n)))
+                             (update-in [ay :alpha] m/some+ (/ j n))
+                             (update-in [ay :beta] m/some+ (/ (- p j) n)))
                          coll)))
                    coll
                    joiner-calendar-years))
@@ -199,8 +198,8 @@
                                (if (= setting-1 s/non-send)
                                  coll
                                  (if (= setting-2 s/non-send)
-                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] u/some+ 1)
-                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :beta] u/some+ 1))))
+                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] m/some+ 1)
+                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :beta] m/some+ 1))))
                              {} transitions)
         prior-per-year (reduce (fn [coll [ay state-betas]]
                                  (let [betas (apply merge-with + (vals state-betas))
@@ -232,7 +231,7 @@
   [transitions-matrix]
   (->> (filter transitions-matrix-joiner? transitions-matrix)
        (reduce (fn [coll {:keys [calendar-year academic-year-2]}]
-                 (update-in coll [calendar-year academic-year-2] u/some+ 1))
+                 (update-in coll [calendar-year academic-year-2] m/some+ 1))
                {})))
 
 (defn calculate-population-per-calendar-year
@@ -262,8 +261,8 @@
                                        (= setting-2 s/non-send))
                                  coll
                                  (if (not= setting-1 setting-2)
-                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] u/some+ 1)
-                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :beta] u/some+ 1))))
+                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] m/some+ 1)
+                                   (update-in coll [academic-year-1 (s/state need-1 setting-1) :beta] m/some+ 1))))
                              {} transitions)
 
         prior-per-year (reduce (fn [coll [ay state-betas]]
@@ -298,7 +297,7 @@
                                  coll
                                  (update-in coll [academic-year-1
                                                   (s/state need-1 setting-1)
-                                                  (s/state need-2 setting-2)] u/some+ 1)))
+                                                  (s/state need-2 setting-2)] m/some+ 1)))
                              {} transitions)
 
         observations-per-ay (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
@@ -306,7 +305,7 @@
                                               (= setting-2 s/non-send)
                                               (= setting-1 setting-2))
                                         coll
-                                        (update-in coll [academic-year-1 setting-2] u/some+ 1)))
+                                        (update-in coll [academic-year-1 setting-2] m/some+ 1)))
                                     {} transitions)
         observations-per-ay (reduce (fn [coll ay]
                                       (if-let [v (or (get coll ay)

--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -1,5 +1,6 @@
 (ns witan.send.params
-  (:require [witan.send.maths :as m]
+  (:require [witan.send.constants :as c]
+            [witan.send.maths :as m]
             [witan.send.states :as s]
             [witan.send.utils :as u]))
 
@@ -15,22 +16,22 @@
 
 (defn joiner?
   [[ay state-1 state-2]]
-  (and (= state-1 s/non-send)
-       (not= state-2 s/non-send)))
+  (and (= state-1 c/non-send)
+       (not= state-2 c/non-send)))
 
 (defn transitions-matrix-joiner?
   [{:keys [need-1]}]
-  (= need-1 s/non-send))
+  (= need-1 c/non-send))
 
 (defn leaver?
   [[ay state-1 state-2]]
-  (and (not= state-1 s/non-send)
-       (= state-2 s/non-send)))
+  (and (not= state-1 c/non-send)
+       (= state-2 c/non-send)))
 
 (defn mover?
   [[ay state-1 state-2]]
-  (and (not= state-1 s/non-send)
-       (not= state-2 s/non-send)
+  (and (not= state-1 c/non-send)
+       (not= state-2 c/non-send)
        (not= state-1 state-2)))
 
 (defn remove-transitions
@@ -195,9 +196,9 @@
                             (distinct)
                             (sort))
         observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2 :as row]}]
-                               (if (= setting-1 s/non-send)
+                               (if (= setting-1 c/non-send)
                                  coll
-                                 (if (= setting-2 s/non-send)
+                                 (if (= setting-2 c/non-send)
                                    (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] m/some+ 1)
                                    (update-in coll [academic-year-1 (s/state need-1 setting-1) :beta] m/some+ 1))))
                              {} transitions)
@@ -257,8 +258,8 @@
                             (distinct)
                             (sort))
         observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
-                               (if (or (= setting-1 s/non-send)
-                                       (= setting-2 s/non-send))
+                               (if (or (= setting-1 c/non-send)
+                                       (= setting-2 c/non-send))
                                  coll
                                  (if (not= setting-1 setting-2)
                                    (update-in coll [academic-year-1 (s/state need-1 setting-1) :alpha] m/some+ 1)
@@ -291,8 +292,8 @@
                             (distinct)
                             (sort))
         observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
-                               (if (or (= setting-1 s/non-send)
-                                       (= setting-2 s/non-send)
+                               (if (or (= setting-1 c/non-send)
+                                       (= setting-2 c/non-send)
                                        (= setting-1 setting-2))
                                  coll
                                  (update-in coll [academic-year-1
@@ -301,8 +302,8 @@
                              {} transitions)
 
         observations-per-ay (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
-                                      (if (or (= setting-1 s/non-send)
-                                              (= setting-2 s/non-send)
+                                      (if (or (= setting-1 c/non-send)
+                                              (= setting-2 c/non-send)
                                               (= setting-1 setting-2))
                                         coll
                                         (update-in coll [academic-year-1 setting-2] m/some+ 1)))

--- a/src/clj/witan/send/schemas.clj
+++ b/src/clj/witan/send/schemas.clj
@@ -1,6 +1,6 @@
 (ns witan.send.schemas
   (:require [schema.core :as s]
-            [schema-contrib.core :as sc]))
+            [witan.send.constants :as c]))
 
 (defn make-ordered-ds-schema [col-vec]
   {:column-names (mapv #(s/one (s/eq (first %)) (str (first %))) col-vec)
@@ -23,13 +23,11 @@
 (def CalendarYear
   (s/constrained s/Int #(<= 1900 % 2100)))
 
-(def non-send :NONSEND)
-
 (defn State
   [needs settings]
   (->> (-> (for [need needs setting settings]
              (keyword (str (name need) "-" (name setting))))
-           (conj non-send))
+           (conj c/non-send))
        (apply s/enum)))
 
 (def academic-years

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -1,18 +1,16 @@
 (ns witan.send.states
   (:require [clojure.string :as str]
-            [witan.send.constants :as const]))
-
-(def non-send :NONSEND)
+            [witan.send.constants :as c]))
 
 (defn need-setting [state]
-  (if (= state non-send)
-    (vector non-send non-send)
+  (if (= state c/non-send)
+    (vector c/non-send c/non-send)
     (mapv keyword (str/split (name state) #"-"))))
 
 (defn state [need setting]
-  (if (or (= setting non-send)
-          (= need non-send))
-    non-send
+  (if (or (= setting c/non-send)
+          (= need c/non-send))
+    c/non-send
     (keyword (str (name need) "-" (name setting)))))
 
 (defn calculate-valid-settings-from-setting-academic-years

--- a/src/clj/witan/send/step.clj
+++ b/src/clj/witan/send/step.clj
@@ -1,13 +1,12 @@
 (ns witan.send.step
-  (:require [witan.send.constants :as const]
-            [witan.send.states :as s]))
+  (:require [witan.send.constants :as c]))
 
 (defn age-population
   [projection model-state]
   (-> (reduce (fn [coll [[year state] population]]
                 (cond-> coll
-                  (< year const/max-academic-year)
+                  (< year c/max-academic-year)
                   (assoc [(inc year) state] population)))
               {}
               model-state)
-      (assoc [const/min-academic-year s/non-send] (get projection const/min-academic-year))))
+      (assoc [c/min-academic-year c/non-send] (get projection c/min-academic-year))))

--- a/src/clj/witan/send/utils.clj
+++ b/src/clj/witan/send/utils.clj
@@ -6,6 +6,7 @@
             [kixi.stats.math :as math]
             [medley.core :as medley]
             [schema.coerce :as coerce]
+            [witan.send.constants :as c]
             [witan.send.maths :as m]
             [witan.send.schemas :as sc]
             [witan.send.states :as states])
@@ -101,7 +102,7 @@
   [model]
   (reduce (fn [coll [[ay state] population]]
             (cond-> coll
-              (not= state sc/non-send)
+              (not= state c/non-send)
               (update ay m/some+ population)))
           {} model))
 
@@ -110,7 +111,7 @@
   (reduce (fn [coll [[ay state] population]]
             (let [[need setting] (states/need-setting state)]
               (cond-> coll
-                (not= state sc/non-send)
+                (not= state c/non-send)
                 (update need m/some+ population))))
           {} model))
 
@@ -119,7 +120,7 @@
   (reduce (fn [coll [[ay state] population]]
             (let [[need setting] (states/need-setting state)]
               (cond-> coll
-                (not= state sc/non-send)
+                (not= state c/non-send)
                 (update setting m/some+ population))))
           {} model))
 
@@ -128,7 +129,7 @@
   (reduce (fn [coll [[ay state] population]]
             (let [[need setting] (states/need-setting state)]
               (cond-> coll
-                (not= state sc/non-send)
+                (not= state c/non-send)
                 (update [need setting] m/some+ population))))
           {} model))
 
@@ -145,7 +146,7 @@
   (reduce (fn [coll [[ay state] population]]
             (let [ay-group (ay-groups ay)]
               (cond-> coll
-                (not= state sc/non-send)
+                (not= state c/non-send)
                 (update ay-group m/some+ population))))
           {} model))
 
@@ -160,7 +161,7 @@
   [model]
   (reduce (fn [n [[ay state] population]]
             (cond-> n
-              (not= state sc/non-send)
+              (not= state c/non-send)
               (+ population)))
           0 model))
 

--- a/test/witan/send/send_test.clj
+++ b/test/witan/send/send_test.clj
@@ -1,11 +1,11 @@
 (ns witan.send.send-test
   (:require [clojure.core.matrix.dataset :as ds]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is testing]]
+            [witan.send.constants :as c]
             [witan.send.model.input :as si]
             [witan.send.model.output :as so]
             [witan.send.params :as p]
             [witan.send.schemas :as sc]
-            [witan.send.send :refer :all]
             [witan.send.utils :as u]))
 
 ;; Use real population datasets for testing
@@ -152,20 +152,20 @@
 
 (deftest mover-rate-test
   (let [mover-count (->> :transition-matrix get-individual-input ds/row-maps (remove (fn [{:keys [setting-1 setting-2]}]
-                                                                                       (or (= setting-1 sc/non-send)
-                                                                                           (= setting-2 sc/non-send)))))
+                                                                                       (or (= setting-1 c/non-send)
+                                                                                           (= setting-2 c/non-send)))))
         result (so/mover-rate mover-count)]
     (testing "output is not empty"
       (is (not= empty? result)))))
 
 (deftest leaver-rate-test
-  (let [leaver-count (->> :transition-matrix get-individual-input ds/row-maps (remove (fn [{:keys [setting-1]}] (= setting-1 sc/non-send))))
+  (let [leaver-count (->> :transition-matrix get-individual-input ds/row-maps (remove (fn [{:keys [setting-1]}] (= setting-1 c/non-send))))
         result (so/leaver-rate leaver-count)]
     (testing "output is not empty"
       (is (not= empty? result)))))
 
 (deftest confidence-bounds-test
-  (let [leaver-rates (->> :transition-matrix get-individual-input ds/row-maps (remove (fn [{:keys [setting-1]}] (= setting-1 sc/non-send))) so/leaver-rate)
+  (let [leaver-rates (->> :transition-matrix get-individual-input ds/row-maps (remove (fn [{:keys [setting-1]}] (= setting-1 c/non-send))) so/leaver-rate)
         result (so/confidence-bounds leaver-rates 2014)]
     (testing "output is not empty"
       (is (not= empty? result) ))


### PR DESCRIPTION
some+ and non-send were defined in two different places and used from all over.