### PR TITLE
Chart improvements

### DIFF
--- a/data/demo/config.edn
+++ b/data/demo/config.edn
@@ -17,7 +17,8 @@
                      :output-dir "results"
                      :settings-to-exclude-in-charts nil
                      :keep-temp-files? false
-                     :use-confidence-bound-or-interval nil}
+                     :use-confidence-bound-or-interval nil
+                     :population-file #ref [:file-inputs :population]}
 
  :validation-parameters {:run-validation false
                          :keep-temp-files? false}}


### PR DESCRIPTION
This is https://www.pivotaltracker.com/story/show/162541051

Create a chart of the "external" ONS population data over NCYs to compare to the SEND NCYs chart.

There is an addition added to the config file, to avoid changing arguments to `output-send-results` and avoid changes to the main ns. Old configs can still be run with this code because the R will not attempt to produce the charts if it doesn't receive a full file path (which is what happens with an old config file)