### PR TITLE
Filtering as described in scenarios.md

### DIFF
--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -231,7 +231,7 @@
                               (transitions-map modified-transitions)
                               (transitions-map transitions))
          transitions-filtered (when filter-transitions-from
-                                (mapcat (fn [year] (filter #(= (:calendar-year %) year)
+                                (mapcat (fn [year] (filter #(> (:calendar-year %) year)
                                                            (or modified-transitions transitions)))
                                         [filter-transitions-from]))
          max-transition-year (apply max (map :calendar-year transitions))


### PR DESCRIPTION
Was just confirm the behaviour and parameters of using `filter-transitions-from` and `splice-ncy` and realised the filtering by year was not acting as I expected and described in scenarios.md. Now fixed, so as to filtering everything less than calendar year parameter

Expected behaviour is: "keep data where calendar year is more than input parameter year"