### PR TITLE
Filter by setting

### DIFF
--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -103,7 +103,7 @@
 
 (defn prep-inputs [initial-send-pop splice-ncy validate-valid-states valid-transitions transitions
                    transitions-filtered population valid-states
-                   original-transitions costs filter-transitions-from]
+                   original-transitions costs]
   (let [start-map {:population-by-state initial-send-pop
                    :valid-states valid-states
                    :transitions original-transitions
@@ -266,13 +266,12 @@
     {:standard-projection (prep-inputs initial-send-pop splice-ncy
                                        validate-valid-states valid-transitions transitions
                                        transitions-filtered
-                                       population valid-states original-transitions costs
-                                       filter-transitions-from)
+                                       population valid-states original-transitions costs)
      :scenario-projection (when modified-transitions
                             (prep-inputs initial-send-pop splice-ncy validate-valid-states
                                          valid-transitions modified-transitions
                                          transitions-filtered population valid-states
-                                         original-transitions costs filter-transitions-from))
+                                         original-transitions costs))
      :modify-transition-by modify-transition-by
      :modify-transitions-from  modify-transitions-from
      :seed-year (inc max-transition-year)}))

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -115,43 +115,46 @@
                                               (group-by :calendar-year)
                                               (medley/map-vals #(total-by-academic-year %)))}]
     (if transitions-filtered
-      (if (int? splice-ncy)
-        (merge start-map
-               {:joiner-beta-params (stitch-ay-params splice-ncy
-                                                      (p/beta-params-joiners validate-valid-states
-                                                                             transitions
-                                                                             (ds/row-maps population))
-                                                      (p/beta-params-joiners validate-valid-states
-                                                                             transitions-filtered
-                                                                             (ds/row-maps population)))
-                :leaver-beta-params (stitch-state-params-by-ay splice-ncy
-                                                               (p/beta-params-leavers validate-valid-states transitions)
-                                                               (p/beta-params-leavers validate-valid-states transitions-filtered))
-                :joiner-state-alphas (stitch-ay-params splice-ncy
-                                                       (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
-                                                       (p/alpha-params-joiners validate-valid-states (transitions-map transitions-filtered)))
+      (cond (int? splice-ncy)
+            (merge start-map
+                   {:joiner-beta-params (stitch-ay-params splice-ncy
+                                                          (p/beta-params-joiners validate-valid-states
+                                                                                 transitions
+                                                                                 (ds/row-maps population))
+                                                          (p/beta-params-joiners validate-valid-states
+                                                                                 transitions-filtered
+                                                                                 (ds/row-maps population)))
+                    :leaver-beta-params (stitch-state-params-by-ay splice-ncy
+                                                                   (stitch-state-params-by-ay splice-ncy
+                                                                                              (p/beta-params-leavers validate-valid-states transitions)
+                                                                                              (p/beta-params-leavers validate-valid-states transitions-filtered))
+                                                                   (p/beta-params-leavers validate-valid-states transitions-filtered))
+                    :joiner-state-alphas (stitch-ay-params splice-ncy
+                                                           (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
+                                                           (p/alpha-params-joiners validate-valid-states (transitions-map transitions-filtered)))
 
-                :mover-beta-params (stitch-state-params-by-ay splice-ncy
-                                                              (p/beta-params-movers validate-valid-states valid-transitions transitions)
-                                                              (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
-                :mover-state-alphas (stitch-state-params-by-ay splice-ncy
-                                                               (p/alpha-params-movers validate-valid-states valid-transitions transitions)
-                                                               (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))})
-        (merge start-map
-               {:joiner-beta-params (p/beta-params-joiners validate-valid-states
-                                                           transitions
-                                                           (ds/row-maps population))
-                :leaver-beta-params (stitch-state-params-by-setting splice-ncy
-                                                                    (p/beta-params-leavers validate-valid-states transitions)
-                                                                    (p/beta-params-leavers validate-valid-states transitions-filtered))
-                :joiner-state-alphas (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
+                    :mover-beta-params (stitch-state-params-by-ay splice-ncy
+                                                                  (p/beta-params-movers validate-valid-states valid-transitions transitions)
+                                                                  (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
+                    :mover-state-alphas (stitch-state-params-by-ay splice-ncy
+                                                                   (p/alpha-params-movers validate-valid-states valid-transitions transitions)
+                                                                   (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))})
+            (string? splice-ncy)
+            (merge start-map
+                   {:joiner-beta-params (p/beta-params-joiners validate-valid-states
+                                                               transitions
+                                                               (ds/row-maps population))
+                    :leaver-beta-params (stitch-state-params-by-setting splice-ncy
+                                                                        (p/beta-params-leavers validate-valid-states transitions)
+                                                                        (p/beta-params-leavers validate-valid-states transitions-filtered))
+                    :joiner-state-alphas (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
 
-                :mover-beta-params (stitch-state-params-by-setting splice-ncy
-                                                                   (p/beta-params-movers validate-valid-states valid-transitions transitions)
-                                                                   (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
-                :mover-state-alphas (stitch-state-params-by-setting splice-ncy
-                                                                    (p/alpha-params-movers validate-valid-states valid-transitions transitions)
-                                                                    (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))}))
+                    :mover-beta-params (stitch-state-params-by-setting splice-ncy
+                                                                       (p/beta-params-movers validate-valid-states valid-transitions transitions)
+                                                                       (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
+                    :mover-state-alphas (stitch-state-params-by-setting splice-ncy
+                                                                        (p/alpha-params-movers validate-valid-states valid-transitions transitions)
+                                                                        (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))}))
       (merge start-map
              {:joiner-beta-params (p/beta-params-joiners validate-valid-states
                                                          transitions

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -126,9 +126,9 @@
               :leaver-beta-params (stitch-state-params-by-ay splice-ncy
                                                              (p/beta-params-leavers validate-valid-states transitions)
                                                              (p/beta-params-leavers validate-valid-states transitions-filtered))
-              :joiner-state-alphas (stitch-ay-params-by-ay splice-ncy
-                                                           (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
-                                                           (p/alpha-params-joiners validate-valid-states (transitions-map transitions-filtered)))
+              :joiner-state-alphas (stitch-state-params-by-ay splice-ncy
+                                                              (p/alpha-params-joiners validate-valid-states transitions)
+                                                              (p/alpha-params-joiners validate-valid-states transitions-filtered))
 
               :mover-beta-params (stitch-state-params-by-ay splice-ncy
                                                             (p/beta-params-movers validate-valid-states valid-transitions transitions)

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -13,7 +13,7 @@
    (let [input (i/build-input-datasets (:project-dir config) (:file-inputs config) (:schema-inputs config))
          validate-input (i/check-if-dataset-is-valid input)]
      (if (= true validate-input)
-       (-> (p/prepare-send-inputs input (:transition-parameters config))
+       (-> (p/prepare-send-inputs input (:scenario-parameters config))
            (r/run-send-model (:projection-parameters config)))
        validate-input))))
 


### PR DESCRIPTION
This is an attempt (may still require some streamlining) to allow [this scenario](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#ignore-historic-data-before-a-specific-calendar-year-for-an-age-group) to accept a setting as well as an academic year. This means that historic data for a specific setting can be filtered when determining leaver and mover parameters.

When applying this scenario, `:splice-ncy` (needs renaming) can accept either an integer (for academic year) or a string (for a setting). 

If this implementation is accepted the [scenarios doc](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md) will also be updated and added to this PR