### PR TITLE
WIP: Explicit priors, use needs + transition output

### DIFF
--- a/src/clj/witan/send/distributions.clj
+++ b/src/clj/witan/send/distributions.clj
@@ -17,6 +17,7 @@
 
 (defn sample-beta-binomial
   [n params]
-  (if (pos? n)
+  (if (and (pos? n)
+           (not= params {:alpha 0 :beta 0}))
     (d/draw (d/beta-binomial n params) {:seed (get-seed!)})
     0))

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -16,65 +16,43 @@
   [{:keys [model transitions academic-year need-setting
            predicted-populations calendar-year]}]
   (vector
-   (reduce (fn [coll [next-need-setting n]]
-             (cond-> coll
-               (pos? n)
-               (update [academic-year next-need-setting] m/some+ n)))
-           model predicted-populations)
-   (reduce (fn [coll [next-need-setting n]]
-             (cond-> coll
-               (pos? n)
-               (update [calendar-year academic-year need-setting next-need-setting] m/some+ n)))
-           transitions predicted-populations)))
-
-(defn predict-movers
-  "Returns a map of predicted need-setting counts for movers for a given
-  `need-setting` and a population `n` with the provided probability
-  distribution parameters.
-
-  Also work out how much of the population remains (non-movers) and
-  add to the results.
-
-  Note: the actual results are the combination of chaining the beta
-  and binomial distributions or the Dirichlet and multinomial
-  distribution.  Beta and Dirichlet are used to sample a distribution
-  and the outcome is selected by the respective binomial or
-  multinomial."
-  [{:keys [need-setting n dirichlet-params beta-params]}]
-  (if (pos? n)
-    (let [mover-n (d/sample-beta-binomial n beta-params)
-          non-mover-n (- n mover-n)]
-      (-> (d/sample-dirichlet-multinomial mover-n dirichlet-params)
-          (assoc need-setting non-mover-n)))
-    {}))
-
-(defn predict-leavers
-  [{:keys [need-setting n beta-params]}]
-  (d/sample-beta-binomial n beta-params))
+    (reduce (fn [coll [next-need-setting n]]
+              (cond-> coll
+                      (pos? n)
+                      (update [academic-year next-need-setting] m/some+ n)))
+            model predicted-populations)
+    (reduce (fn [coll [next-need-setting n]]
+              (cond-> coll
+                      (pos? n)
+                      (update [calendar-year (dec academic-year) need-setting next-need-setting] m/some+ n)))
+            transitions predicted-populations)))
 
 (defn apply-leavers-movers-for-cohort-unsafe
   "We're calling this function 'unsafe' because it doesn't check whether the need-setting or
   or academic year range is valid."
   [[model transitions] [[year need-setting] population]
    {:keys [mover-state-alphas mover-beta-params leaver-beta-params
-           valid-year-settings] :as params}
+           valid-year-settings valid-ay-need-settings] :as params}
    calendar-year]
   (if-let [mover-dirichlet-params (get mover-state-alphas [(dec year) need-setting])]
-    (let [leavers (predict-leavers {:need-setting need-setting
-                                    :n population
-                                    :beta-params (get leaver-beta-params [(dec year) need-setting])})
-          movers (if (states/can-move? valid-year-settings year need-setting)
-                               (predict-movers {:need-setting need-setting
-                                                :n (- population leavers)
-                                                :beta-params (get mover-beta-params [(dec year) need-setting])
-                                                :dirichlet-params mover-dirichlet-params})
-                               {need-setting (- population leavers)})
+    (let [leaver-beta-params (get leaver-beta-params [(dec year) need-setting])
+          leavers (d/sample-beta-binomial population leaver-beta-params)
+          mover-beta-params (get mover-beta-params [(dec year) need-setting])
+          movers-n (d/sample-beta-binomial (- population leavers) mover-beta-params)
+          movers (d/sample-dirichlet-multinomial movers-n mover-dirichlet-params)
+          remainers-n (- population leavers movers-n)
           [model transitions] (incorporate-new-ay-need-setting-populations {:model model :transitions transitions
                                                                             :academic-year year :need-setting need-setting
                                                                             :predicted-populations movers
-                                                                            :calendar-year calendar-year})]
-      [model
-       (update transitions [calendar-year year need-setting c/non-send] m/some+ leavers)])
+                                                                            :calendar-year calendar-year})
+          [model transitions] (if (some #{[year need-setting]} valid-ay-need-settings)
+                                (incorporate-new-ay-need-setting-populations {:model model :transitions transitions
+                                                                              :academic-year year :need-setting need-setting
+                                                                              :predicted-populations {need-setting remainers-n}
+                                                                              :calendar-year calendar-year})
+                                [model (update transitions [calendar-year (dec year) need-setting c/non-send] m/some+ remainers-n)])
+          ]
+      [model (update transitions [calendar-year (dec year) need-setting c/non-send] m/some+ leavers)])
     [model transitions]))
 
 (defn apply-leavers-movers-for-cohort
@@ -91,8 +69,8 @@
         (> year sc/max-academic-year))
     [model
      (cond-> transitions
-       (pos? population)
-       (update [calendar-year year state c/non-send] m/some+ population))]
+             (pos? population)
+             (update [calendar-year (dec year) state c/non-send] m/some+ population))]
     :else
     (apply-leavers-movers-for-cohort-unsafe population-by-state cohort params calendar-year)))
 
@@ -176,7 +154,7 @@
                   (values-rf {:by-state (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
                               :total-in-send-by-ay (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
                               :total-in-send (u/histogram-combiner-rf simulations number-of-significant-digits)
-                              :total-in-send-by-need (u/merge-with-rf (u/histogram-combiner-rf simulations  number-of-significant-digits))
+                              :total-in-send-by-need (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
                               :total-in-send-by-setting (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
                               :total-cost (u/histogram-combiner-rf simulations number-of-significant-digits)
                               :total-in-send-by-ay-group (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))})))
@@ -194,8 +172,8 @@
                 valid-states transitions] :as inputs} standard-projection
         modified-inputs (when ((complement nil?) scenario-projection)
                           (assoc scenario-projection :valid-year-settings
-                                 (->> (ds/row-maps valid-states)
-                                      (states/calculate-valid-year-settings-from-setting-academic-years))))
+                                                     (->> (ds/row-maps valid-states)
+                                                          (states/calculate-valid-year-settings-from-setting-academic-years))))
         projected-future-pop-by-year (->> projected-population
                                           (filter (fn [[k _]] (> k seed-year)))
                                           (sort-by key))
@@ -203,7 +181,8 @@
         validate-valid-states (->> (ds/row-maps valid-states)
                                    (states/calculate-valid-states-from-setting-academic-years))
         inputs (assoc inputs :valid-year-settings (->> (ds/row-maps valid-states)
-                                                       (states/calculate-valid-year-settings-from-setting-academic-years)))
+                                                       (states/calculate-valid-year-settings-from-setting-academic-years))
+                             :valid-ay-need-settings validate-valid-states)
         projections (->> (range simulations)
                          ;; The logic is for validation compatibility only, elsewise we could just use the truth expression
                          (partition-all (if (< simulations 8)
@@ -218,12 +197,13 @@
                                       (doall))))
                          (doall))
         reduced (doall
-                 (for [projection projections]
-                   (do (println "Reducing...")
-                       (transduce (map #(map :model %)) (reduce-rf iterations validate-valid-states cost-lookup) projection))))
+                  (for [projection projections]
+                    (do (println "Reducing...")
+                        (transduce (map #(map :model %)) (reduce-rf iterations validate-valid-states cost-lookup) projection))))
         projection (apply concat projections)]
     (println "Combining...")
     {:projection (projection->transitions projection)
+     :simulations simulations
      :send-output (transduce identity (combine-rf simulations iterations) reduced)
      :transitions transitions
      :valid-states valid-states

--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -17,8 +17,8 @@
   [transitions pred]
   (reduce (fn [coll [transition n]]
             (cond-> coll
-              (pred transition)
-              (assoc transition n)))
+                    (pred transition)
+                    (assoc transition n)))
           {}
           transitions))
 
@@ -35,20 +35,17 @@
   [[ay _ _]]
   ay)
 
-(defn continue-for-latter-ays [params academic-years]
-  (reduce (fn [coll ay]
-            (if-let [v (or (get coll ay)
-                           nil)] ;; Replace with average of adjacent AY params
-              (assoc coll ay v)
-              coll))
-          params (sort academic-years)))
-
 (defn calculate-joiners-per-calendar-year
+  "The result maps keys are used to lookup up external population so need to be added
+   even though there is no observed count"
   [transitions]
-  (->> (filter transitions-joiner? transitions)
-       (reduce (fn [coll {:keys [calendar-year academic-year-2]}]
-                 (update-in coll [calendar-year academic-year-2] m/some+ 1))
-               {})))
+  (let [observed-calendar-years (into #{} (map :calendar-year transitions))
+        joiners-per-calendar-year (into {} (for [cy observed-calendar-years] [cy {}]))]
+    (->> (filter transitions-joiner? transitions)
+         (reduce (fn [coll {:keys [calendar-year academic-year-2]}]
+                   (update-in coll [calendar-year academic-year-2] m/some+ 1))
+                 {})
+         (merge joiners-per-calendar-year))))
 
 (defn calculate-population-per-calendar-year
   [population]
@@ -58,9 +55,6 @@
             {}
             population)))
 
-(defn any-valid-transitions? [state valid-transitions]
-  (< 1 (count (get valid-transitions (second (s/split-need-setting state))))))
-;; informal api
 (defn beta-params-leavers [valid-states transitions]
   (let [academic-years (->> (map first valid-states)
                             (distinct)
@@ -80,11 +74,15 @@
                                    (assoc coll ay {:alpha (double (/ alpha total))
                                                    :beta (double (/ beta total))})))
                                {} observations)
-        prior-per-year (continue-for-latter-ays prior-per-year academic-years)]
+        unobserved-priors (reduce (fn [coll ay]
+                                    (if (nil? (get observations ay))
+                                      (assoc coll ay {:alpha 0.5 :beta 0.5}))) ; these prior values need tweaking
+                                  {} academic-years)]
     (reduce (fn [coll [ay state]]
               (if-let [beta-params (merge-with +
                                                (get-in observations [ay state])
-                                               (get prior-per-year ay))]
+                                               (get prior-per-year ay)
+                                               (get unobserved-priors ay))]
                 (assoc coll [ay state] beta-params)
                 coll))
             {} valid-states)))
@@ -97,56 +95,64 @@
         joiner-calendar-years (keys joiners)
         population (calculate-population-per-calendar-year population)
         academic-years (->> (map first valid-states) distinct sort)
-        n (count joiner-calendar-years)
-        params (reduce
-                (fn [coll ay]
-                  (reduce
-                   (fn [coll cy]
-                     (let [j (get-in joiners [cy ay])
-                           p (get-in population [cy ay])]
-                       (if j
-                         (-> coll
-                             (update-in [ay :alpha] m/some+ (/ j n))
-                             (update-in [ay :beta] m/some+ (/ (- p j) n)))
-                         coll)))
-                   coll
-                   joiner-calendar-years))
-                {}
-                academic-years)]
-    (continue-for-latter-ays params academic-years)))
+        n (count joiner-calendar-years)]
+    (reduce
+      (fn [coll ay]
+        (reduce
+          (fn [coll cy]
+            (let [j (get-in joiners [cy ay])
+                  p (get-in population [cy ay])]
+              (if j
+                (-> coll
+                    (update-in [ay :alpha] m/some+ (/ j n))
+                    (update-in [ay :beta] m/some+ (/ (- p j) n)))
+                (-> coll
+                    (update-in [ay :alpha] m/some+ 0.001)   ; if no joiner data add tiny amount and ensure we add non-joiner info
+                    (update-in [ay :beta] m/some+ (/ p n))))))
+          coll
+          joiner-calendar-years))
+      {}
+      academic-years)))
 
 (defn beta-params-movers
   "calculates the rate of the likelihood of a state transitioning for an academic year"
-  [valid-states valid-transitions transitions]
+  [valid-states valid-year-settings transitions]
   (let [academic-years (->> (map first valid-states)
                             (distinct)
                             (sort))
-        observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 setting-2]}]
-                               (if (or (= setting-1 c/non-send)
+        observations (reduce (fn [coll {:keys [academic-year-1 need-1 need-2 setting-1 setting-2]}]
+                               (if (or (= setting-1 c/non-send) ; leaver or joiner
                                        (= setting-2 c/non-send))
                                  coll
-                                 (if (not= setting-1 setting-2)
+                                 (if (not (and (= setting-1 setting-2) ; not a remainer
+                                               (= need-1 need-2)))
                                    (update-in coll [academic-year-1 (s/join-need-setting need-1 setting-1) :alpha] m/some+ 1)
                                    (update-in coll [academic-year-1 (s/join-need-setting need-1 setting-1) :beta] m/some+ 1))))
                              {} transitions)
-
-        prior-per-year (reduce (fn [coll [ay state-betas]]
-                                 (let [betas (apply merge-with + (vals state-betas))
+        prior-per-year (reduce (fn [coll [ay need-setting-betas]]
+                                 (let [betas (apply merge-with + (vals need-setting-betas))
                                        alpha (+ (get betas :alpha 0) 0.5)
                                        beta (+ (get betas :beta 0) 0.5)
                                        total (+ alpha beta)]
                                    (assoc coll ay {:alpha (double (/ alpha total))
                                                    :beta (double (/ beta total))})))
                                {} observations)
-        prior-per-year (continue-for-latter-ays prior-per-year academic-years)]
-    (reduce (fn [coll [ay state]]
-              (if (any-valid-transitions? state valid-transitions)
-                (if-let [beta-params (merge-with +
-                                                 (get-in observations [ay state])
-                                                 (get prior-per-year ay))]
-                  (assoc coll [ay state] beta-params)
+        unobserved-priors (reduce (fn [coll ay]
+                                    (if (nil? (get observations ay))
+                                      (assoc coll ay {:alpha 1 :beta 1}))) ; these prior values need tweaking
+                                  {} academic-years)]
+    (reduce (fn [coll [ay need-setting]]
+              (let [[_ setting] (s/split-need-setting need-setting)
+                    aged-on-valid-settings (get valid-year-settings (inc ay))]
+                (if (get aged-on-valid-settings setting)
+                  (if-let [beta-params (merge-with +
+                                                   (get-in observations [ay need-setting])
+                                                   (get prior-per-year ay)
+                                                   (get unobserved-priors ay))]
+                    (assoc coll [ay need-setting] beta-params)
+                    coll)
                   coll)
-                coll))
+                ))
             {} valid-states)))
 
 (defn alpha-params-joiners
@@ -165,33 +171,49 @@
   An :NONSEND-NONSEND can be shorted to :NONSEND
   The ay_n+1 can be ommitted and assumed."
   [valid-states transitions]
-  (let [by-ay (-> transitions
-                  (select-transitions joiner?)
+  (let [joiner-transitions (-> transitions (select-transitions joiner?))
+        number-of-unique-joiner-transitions (reduce (fn [c r] (+ c (second r))) 0 joiner-transitions)
+        by-ay (-> joiner-transitions
                   (alpha-params (juxt academic-year state-2)))
         academic-years (->> valid-states (map first) distinct sort)
-        params (reduce (fn [coll ay]
-                         (let [valid-states (s/validate-states-for-ay valid-states ay)
-                               prior-alphas (zipmap valid-states (repeat (/ 1.0 (count valid-states))))]
-                           (if-let [v (get by-ay ay)]
-                             (assoc coll ay (merge-with + prior-alphas v))
-                             coll)))
-                       {}
-                       academic-years)]
-    (continue-for-latter-ays params academic-years)))
+        dirichlet (reduce (fn [coll ay]
+                            (let [valid-states (s/validate-states-for-ay valid-states ay)
+                                  prior-alphas (zipmap valid-states (repeat (/ 1.0 (count valid-states))))]
+                              (if-let [v (get by-ay ay)]
+                                (assoc coll ay (merge-with + prior-alphas v))
+                                ; no observed prior
+                                (assoc coll ay prior-alphas))))
+                          {}
+                          academic-years)
+        dirichlet-parameter-space-size (reduce (fn [c row] (+ c (count (second row)))) 0 dirichlet)]
+    (println (str "\nnumber-of-unique-joiner-transitions: " number-of-unique-joiner-transitions))
+    (println (str "joiner-dirichlet-parameter-space-size:" dirichlet-parameter-space-size))
+    (println (str "joiner-percentage-of-dirichlet-using-only-priors: " (- 100 (double (* 100 (/ number-of-unique-joiner-transitions dirichlet-parameter-space-size))))))
+    dirichlet))
 
+(defn cart [colls]
+  (if (empty? colls)
+    '(())
+    (for [x (first colls)
+          more (cart (rest colls))]
+      (into [] (cons x more)))))
 
 (defn- mover-alpha-prior
   "Calculate prior by adding uniform distribution across allowed settings to observations and normalising."
-  [need-setting valid-transitions valid-settings observations-per-ay ay]
+  [need-setting valid-transitions valid-settings aged-on-valid-settings valid-needs observations-per-ay ay]
   (let [[need setting] (s/split-need-setting need-setting)
         allowed-settings (set/intersection (set (get valid-settings [ay need]))
-                                           (set (get valid-transitions setting)))
-        prior (as-> allowed-settings s
-                (zipmap s (repeat (/ 1.0 (count allowed-settings))))
-                (merge-with + (get observations-per-ay ay) s)
-                (dissoc s setting))
+                                           (set (get valid-transitions setting))
+                                           aged-on-valid-settings)
+        allowed-needs (get valid-needs [ay setting])
+        allowed-need-settings (cart [allowed-needs allowed-settings])
+        prior (as-> allowed-need-settings s
+                    (zipmap s (repeat (/ 1.0 (count allowed-need-settings))))
+                    (into {} (for [[[need setting] v] s]
+                               [[need setting] (+ (get-in observations-per-ay [ay setting] 0) v)]))
+                    (dissoc s [need setting]))
         total (reduce + (vals prior))]
-    (reduce (fn [coll [setting v]]
+    (reduce (fn [coll [[need setting] v]]
               (assoc coll (s/join-need-setting need setting) (double (/ v total))))
             {}
             prior)))
@@ -214,25 +236,44 @@
 
 (defn alpha-params-movers
   "calculates the rate of transitions to a new state at academic year X for state Y"
-  [valid-states valid-transitions transitions]
-  (let [mover-transitions (remove (fn [{:keys [setting-1 setting-2]}]
+  [valid-states valid-year-settings valid-transitions transitions]
+  (let [mover-transitions (remove (fn [{:keys [setting-1 setting-2 need-1 need-2]}]
                                     (or (= setting-1 c/non-send)
                                         (= setting-2 c/non-send)
-                                        (= setting-1 setting-2)))
+                                        (and (= setting-1 setting-2)
+                                             (= need-1 need-2))))
                                   transitions)
+        number-of-mover-transitions (count mover-transitions)
+        number-of-unique-mover-transitions (count (group-by (juxt :setting-1 :need-1
+                                                                  :academic-year-1 :setting-2
+                                                                  :need-2 :academic-year-2) mover-transitions))
         observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
                                (update-in coll [academic-year-1
                                                 (s/join-need-setting need-1 setting-1)
                                                 (s/join-need-setting need-2 setting-2)] m/some+ 1))
                              {} mover-transitions)
-        valid-settings (s/calculate-valid-settings-for-need-ay valid-states)]
-    (reduce (fn [coll [ay need-setting]]
-              (let [obs-for-ay (get-in observations [ay need-setting])
-                    prior (mover-alpha-prior need-setting
-                                             valid-transitions
-                                             valid-settings
-                                             (mover-observations-per-ay valid-states mover-transitions)
-                                             ay)]
-                (assoc coll [ay need-setting] (merge-with + prior obs-for-ay))))
-            {}
-            valid-states)))
+        valid-settings (s/calculate-valid-settings-for-need-ay valid-states)
+        valid-needs (s/calculate-valid-needs-for-setting-ay valid-states)
+        dirichlet (reduce (fn [coll [ay need-setting]]
+                            (let [[_ setting] (s/split-need-setting need-setting)
+                                  aged-on-valid-settings (get valid-year-settings (inc ay))]
+                              (if (get aged-on-valid-settings setting)
+                                (let [obs-for-ay (get-in observations [ay need-setting])
+                                      prior (mover-alpha-prior need-setting
+                                                               valid-transitions
+                                                               valid-settings
+                                                               aged-on-valid-settings
+                                                               valid-needs
+                                                               (mover-observations-per-ay valid-states mover-transitions)
+                                                               ay)]
+                                  (assoc coll [ay need-setting] (merge-with + prior obs-for-ay)))
+                                coll)))
+                          {}
+                          valid-states)
+        dirichlet-parameter-space-size (reduce (fn [c row] (+ c (count (second row)))) 0 dirichlet)]
+    (println (str "\nnumber-of-mover-transitions:" number-of-mover-transitions))
+    (println (str "number-of-unique-mover-transitions: " number-of-unique-mover-transitions))
+    (println (str "dirichlet-parameter-space-size:" dirichlet-parameter-space-size))
+    (println (str "percentage-of-dirichlet-using-only-priors: " (- 100 (double (* 100 (/ number-of-unique-mover-transitions dirichlet-parameter-space-size))))))
+    dirichlet
+    ))

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -42,9 +42,16 @@
        (map (fn [[ay' state]] state))))
 
 (defn calculate-valid-settings-for-need-ay [valid-states]
-  (reduce (fn [coll [ay state]]
-            (let [[need setting] (split-need-setting state)]
-              (update coll [ay need] (fnil conj #{}) setting)))
+  (let [vs (reduce (fn [coll [ay need-setting]]
+                     (let [[need setting] (split-need-setting need-setting)]
+                       (update coll [ay need] (fnil conj #{}) setting)))
+                   {} valid-states)]
+    vs))
+
+(defn calculate-valid-needs-for-setting-ay [valid-states]
+  (reduce (fn [coll [ay need-setting]]
+            (let [[need setting] (split-need-setting need-setting)]
+              (update coll [ay setting] (fnil conj #{}) need)))
           {} valid-states))
 
 (defn aggregate-setting->setting [setting setting->setting]
@@ -77,3 +84,9 @@
 (defn can-move? [valid-year-settings academic-year state]
   (let [[need setting] (split-need-setting state)]
     (pos? (count (disj (get valid-year-settings (inc academic-year)) setting)))))
+
+(defn capable-of-moving?
+  "All entities are capable of moving as need movement is unrestricted except in the last possible year
+  when everyone must leave"
+  [ay]
+  (< ay c/max-academic-year))

--- a/test/witan/send/params_test.clj
+++ b/test/witan/send/params_test.clj
@@ -54,7 +54,7 @@
 
   (testing "Positive mover state alphas for every year with >1 setting"
     (let [transitions {}
-          params (sut/alpha-params-movers valid-states valid-transitions transitions)]
+          params (sut/alpha-params-movers valid-states valid-year-settings valid-transitions transitions)]
       (is (empty? (remove (fn [[academic-year state]]
                             (let [alphas (get params [academic-year state])]
                               (and (pos? (count alphas))
@@ -74,7 +74,7 @@
 
   (testing "Positive mover beta params for every valid state"
     (let [transitions {}
-          params (sut/beta-params-movers valid-states valid-transitions transitions)]
+          params (sut/beta-params-movers valid-states valid-year-settings transitions)]
       (is (every? (fn [[_ betas]]
                     (and (pos? (:alpha betas))
                          (pos? (:beta betas))))


### PR DESCRIPTION
Here's a summary of the changes I've made needed to get a very small transitions data set producing sensible results.  The impact on client data runs seems small.

I'd like to go over these changes and get agreement that the results are correct and then establish unit tests for the various distro calculations and acceptance tests over some small data sets.

* adds output transition data as a CSV
* changes transition data to use the ay "from" in the transition output (for consistency with input transitions)
* remainers that would have aged to invalid group and then be removed via the cleanup are now explicitly prevented and added to the transitions file as leavers
* fixed a joiner beta calculation bug in which no observed joiners also means we also don't count the number of non-joiners for a calendar year 
* added unobserved priors for mover beta distribution (rather than fall back to kixi.stats default)
* added unobserved priors for leaver beta distribution (rather than fall back to kixi.stats default)
* added needs to the mover dirichlet prior calculation
* fixed mover distribution calculations to allow the possibility of transitioning between need within the same setting.