### PR TITLE
add count of missing costs in transitions to report

### DIFF
--- a/test/witan/send/check_inputs_test.clj
+++ b/test/witan/send/check_inputs_test.clj
@@ -8,8 +8,8 @@
 
 
 (deftest cost-for-need-setting?-tests
-  (is (= true (cost-for-need-setting? {:need :X, :setting :Y} test-setting-costs)))
-  (is (= false (cost-for-need-setting? {:need :X, :setting :Z} test-setting-costs))))
+  (is (= true (cost-for-need-setting? '(:X :Y) test-setting-costs)))
+  (is (= false (cost-for-need-setting? '(:X :Z) test-setting-costs))))
 
 
 (deftest valid-ay-for-state?-tests


### PR DESCRIPTION
This extends the missing cost input check to count the number of times each missing costs occurs in the transitions input. This is useful to feedback to clients where they should focus on if they need to fix costs, and also as a warning to us if a common entity is missing a cost (and will be used as zero)