### PR TITLE
Fix validation dirs

### DIFF
--- a/src/clj/witan/send/validate_model.clj
+++ b/src/clj/witan/send/validate_model.clj
@@ -108,10 +108,10 @@
   "Takes seq of maps containing results returned by (validate-fold) and writes to disk"
   (->> (map :count results)
        flatten
-       (write-csv (io/file project-dir (str "validation-" output-dir "/validation_results_count.csv"))))
+       (write-csv (io/file project-dir output-dir "validation_results_count.csv")))
   (->> (map :state results)
        flatten
-       (write-csv (io/file project-dir (str "validation-" output-dir "/validation_results_state.csv")))))
+       (write-csv (io/file project-dir output-dir "validation_results_state.csv"))))
 
 (defn setup-validation-dirs [project-dir output-dir]
   "Create dirs required for validation process"

--- a/test/witan/send/acceptance/validate_model_test.clj
+++ b/test/witan/send/acceptance/validate_model_test.clj
@@ -12,8 +12,8 @@
         files (keys expected-md5s)
         config (m/read-config "data/demo/config.edn")
         output-dir (get-in config [:output-parameters :output-dir])
-        validation-dir (join "/" [(:project-dir config) (str "validation-" output-dir)])]
-    (run! #(let [file (join "/" [validation-dir %])]
+        validation-dir (io/file (:project-dir config) output-dir)]
+    (run! #(let [file (io/file validation-dir %)]
              (when (.exists (io/file file))
                (io/delete-file file))) files)
     (vm/run-send-validation config)


### PR DESCRIPTION
Small change to make the validation outputs play more nicely with the new client repo structure (validation was throwing an IO error toggling it on directly with their current structure).

This is a branch of a branch because I needed the testing, and wanted to avoid merge pains.. Hopefully, I've not made that harder and this can just be easily merged after #158 
