### PR TITLE
Output transitions branch with white space changes nuked

### DIFF
--- a/src/clj/witan/send/distributions.clj
+++ b/src/clj/witan/send/distributions.clj
@@ -17,6 +17,7 @@
 
 (defn sample-beta-binomial
   [n params]
-  (if (pos? n)
+  (if (and (pos? n)
+           (not= params {:alpha 0 :beta 0}))
     (d/draw (d/beta-binomial n params) {:seed (get-seed!)})
     0))

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -88,7 +88,8 @@
    b))
 
 (defn prep-inputs [initial-send-pop splice-ncy validate-valid-states valid-transitions transitions
-                   transitions-filtered population valid-states original-transitions costs]
+                   transitions-filtered population valid-states valid-year-settings
+                   original-transitions costs]
   (let [start-map {:population-by-state initial-send-pop
                    :valid-states valid-states
                    :transitions original-transitions
@@ -116,19 +117,24 @@
                                                      (p/alpha-params-joiners validate-valid-states (transitions-map transitions-filtered)))
 
               :mover-beta-params (stitch-state-params splice-ncy
-                                                      (p/beta-params-movers validate-valid-states valid-transitions transitions)
-                                                      (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
+                                                      (p/beta-params-movers validate-valid-states valid-year-settings transitions)
+                                                      (p/beta-params-movers validate-valid-states valid-year-settings transitions-filtered))
               :mover-state-alphas (stitch-state-params splice-ncy
-                                                       (p/alpha-params-movers validate-valid-states valid-transitions transitions)
-                                                       (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))})
+                                                       (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions)
+                                                       (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions-filtered))
+              :validate-valid-states validate-valid-states
+              :valid-transitions valid-transitions
+              :valid-year-settings valid-year-settings})
       (merge start-map
              {:joiner-beta-params (p/beta-params-joiners validate-valid-states
                                                          transitions
                                                          (ds/row-maps population))
               :leaver-beta-params (p/beta-params-leavers validate-valid-states transitions)
               :joiner-state-alphas (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
-              :mover-beta-params (p/beta-params-movers validate-valid-states valid-transitions transitions)
-              :mover-state-alphas  (p/alpha-params-movers validate-valid-states valid-transitions transitions)}))))
+              :mover-beta-params (p/beta-params-movers validate-valid-states valid-year-settings transitions)
+              :mover-state-alphas (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions)
+              :validate-valid-states validate-valid-states
+              :valid-transitions valid-transitions}))))
 
 (defn generate-transition-key [{:keys [transition-type cy ay need setting move-state]}]
   (when (not= move-state (states/join-need-setting need setting))
@@ -213,6 +219,7 @@
                                 initialise-validation)
          valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years
                               initialise-validation)
+
          transitions-to-change (when modify-transition-by
                                  (mapcat (fn [transition-type]
                                            (build-transitions-to-change settings-to-change
@@ -251,11 +258,11 @@
     {:standard-projection (prep-inputs initial-send-pop splice-ncy
                                        validate-valid-states valid-transitions transitions
                                        transitions-filtered
-                                       population valid-states original-transitions costs)
+                                       population valid-states valid-year-settings original-transitions costs)
      :scenario-projection (when modified-transitions
                             (prep-inputs initial-send-pop splice-ncy validate-valid-states
                                          valid-transitions modified-transitions
-                                         transitions-filtered population valid-states
+                                         transitions-filtered population valid-states valid-year-settings
                                          original-transitions costs))
      :modify-transition-by modify-transition-by
      :modify-transitions-from  modify-transitions-from

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -42,9 +42,16 @@
        (map (fn [[ay' state]] state))))
 
 (defn calculate-valid-settings-for-need-ay [valid-states]
-  (reduce (fn [coll [ay state]]
-            (let [[need setting] (split-need-setting state)]
+  (let [vs (reduce (fn [coll [ay need-setting]]
+                     (let [[need setting] (split-need-setting need-setting)]
               (update coll [ay need] (fnil conj #{}) setting)))
+                   {} valid-states)]
+    vs))
+
+(defn calculate-valid-needs-for-setting-ay [valid-states]
+  (reduce (fn [coll [ay need-setting]]
+            (let [[need setting] (split-need-setting need-setting)]
+              (update coll [ay setting] (fnil conj #{}) need)))
           {} valid-states))
 
 (defn aggregate-setting->setting [setting setting->setting]
@@ -77,3 +84,9 @@
 (defn can-move? [valid-year-settings academic-year state]
   (let [[need setting] (split-need-setting state)]
     (pos? (count (disj (get valid-year-settings (inc academic-year)) setting)))))
+
+(defn capable-of-moving?
+  "All entities are capable of moving as need movement is unrestricted except in the last possible year
+  when everyone must leave"
+  [ay]
+  (< ay c/max-academic-year))

--- a/test/witan/send/params_test.clj
+++ b/test/witan/send/params_test.clj
@@ -54,7 +54,7 @@
 
   (testing "Positive mover state alphas for every year with >1 setting"
     (let [transitions {}
-          params (sut/alpha-params-movers valid-states valid-transitions transitions)]
+          params (sut/alpha-params-movers valid-states valid-year-settings valid-transitions transitions)]
       (is (empty? (remove (fn [[academic-year state]]
                             (let [alphas (get params [academic-year state])]
                               (and (pos? (count alphas))
@@ -74,7 +74,7 @@
 
   (testing "Positive mover beta params for every valid state"
     (let [transitions {}
-          params (sut/beta-params-movers valid-states valid-transitions transitions)]
+          params (sut/beta-params-movers valid-states valid-year-settings transitions)]
       (is (every? (fn [[_ betas]]
                     (and (pos? (:alpha betas))
                          (pos? (:beta betas))))


### PR DESCRIPTION
Here's a summary of the changes I've made needed to get a very small transitions data set producing sensible results. The impact on client data runs seems small.

I'd like to go over these changes and get agreement that the results are correct and then establish unit tests for the various distro calculations and acceptance tests over some small data sets.

* adds output transition data as a CSV
* changes transition data to use the ay "from" in the transition output (for consistency with input transitions)
* remainers that would have aged to invalid group and then be removed via the cleanup are now explicitly prevented and added to the transitions file as leavers
* fixed a joiner beta calculation bug in which no observed joiners also means we also don't count the number of non-joiners for a calendar year
* added unobserved priors for mover beta distribution (rather than fall back to kixi.stats default)
* added unobserved priors for leaver beta distribution (rather than fall back to kixi.stats default)
* added needs to the mover dirichlet prior calculation
* fixed mover distribution calculations to allow the possibility of transitioning between need within the same setting.