### PR TITLE
WIP (do not review): Many tech debt bug fixes

### DIFF
--- a/src/clj/witan/send/distributions.clj
+++ b/src/clj/witan/send/distributions.clj
@@ -17,6 +17,7 @@
 
 (defn sample-beta-binomial
   [n params]
-  (if (pos? n)
+  (if (and (pos? n)
+           (not= params {:alpha 0 :beta 0}))
     (d/draw (d/beta-binomial n params) {:seed (get-seed!)})
     0))

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -88,7 +88,8 @@
    b))
 
 (defn prep-inputs [initial-send-pop splice-ncy validate-valid-states valid-transitions transitions
-                   transitions-filtered population valid-states original-transitions costs]
+                   transitions-filtered population valid-states valid-year-settings
+                   original-transitions costs]
   (let [start-map {:population-by-state initial-send-pop
                    :valid-states valid-states
                    :transitions original-transitions
@@ -116,19 +117,24 @@
                                                      (p/alpha-params-joiners validate-valid-states (transitions-map transitions-filtered)))
 
               :mover-beta-params (stitch-state-params splice-ncy
-                                                      (p/beta-params-movers validate-valid-states valid-transitions transitions)
-                                                      (p/beta-params-movers validate-valid-states valid-transitions transitions-filtered))
+                                                      (p/beta-params-movers validate-valid-states valid-year-settings transitions)
+                                                      (p/beta-params-movers validate-valid-states valid-year-settings transitions-filtered))
               :mover-state-alphas (stitch-state-params splice-ncy
-                                                       (p/alpha-params-movers validate-valid-states valid-transitions transitions)
-                                                       (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered))})
+                                                       (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions)
+                                                       (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions-filtered))
+              :validate-valid-states validate-valid-states
+              :valid-transitions valid-transitions
+              :valid-year-settings valid-year-settings})
       (merge start-map
              {:joiner-beta-params (p/beta-params-joiners validate-valid-states
                                                          transitions
                                                          (ds/row-maps population))
               :leaver-beta-params (p/beta-params-leavers validate-valid-states transitions)
               :joiner-state-alphas (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
-              :mover-beta-params (p/beta-params-movers validate-valid-states valid-transitions transitions)
-              :mover-state-alphas  (p/alpha-params-movers validate-valid-states valid-transitions transitions)}))))
+              :mover-beta-params (p/beta-params-movers validate-valid-states valid-year-settings transitions)
+              :mover-state-alphas (p/alpha-params-movers validate-valid-states valid-year-settings valid-transitions transitions)
+              :validate-valid-states validate-valid-states
+              :valid-transitions valid-transitions}))))
 
 (defn generate-transition-key [{:keys [transition-type cy ay need setting move-state]}]
   (when (not= move-state (states/join-need-setting need setting))
@@ -213,6 +219,7 @@
                                 initialise-validation)
          valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years
                               initialise-validation)
+
          transitions-to-change (when modify-transition-by
                                  (mapcat (fn [transition-type]
                                            (build-transitions-to-change settings-to-change
@@ -251,11 +258,11 @@
     {:standard-projection (prep-inputs initial-send-pop splice-ncy
                                        validate-valid-states valid-transitions transitions
                                        transitions-filtered
-                                       population valid-states original-transitions costs)
+                                       population valid-states valid-year-settings original-transitions costs)
      :scenario-projection (when modified-transitions
                             (prep-inputs initial-send-pop splice-ncy validate-valid-states
                                          valid-transitions modified-transitions
-                                         transitions-filtered population valid-states
+                                         transitions-filtered population valid-states valid-year-settings
                                          original-transitions costs))
      :modify-transition-by modify-transition-by
      :modify-transitions-from  modify-transitions-from

--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -35,14 +35,6 @@
   [[ay _ _]]
   ay)
 
-(defn continue-for-latter-ays [params academic-years]
-  (reduce (fn [coll ay]
-            (if-let [v (or (get coll ay)
-                           nil)] ;; Replace with average of adjacent AY params
-              (assoc coll ay v)
-              coll))
-          params (sort academic-years)))
-
 (defn calculate-joiners-per-calendar-year
   "The result maps keys are used to lookup up external population so need to be added
    even though there is no observed count"
@@ -62,9 +54,6 @@
               (update coll calendar-year merge (ay-population row)))
             {}
             population)))
-
-(defn any-valid-transitions? [state valid-transitions]
-  (< 1 (count (get valid-transitions (second (s/split-need-setting state))))))
 
 (defn beta-params-leavers [valid-states transitions]
   (let [academic-years (->> (map first valid-states)
@@ -128,19 +117,19 @@
 
 (defn beta-params-movers
   "calculates the rate of the likelihood of a need-setting transitioning for an academic year"
-  [valid-states valid-transitions transitions]
+  [valid-states valid-year-settings transitions]
   (let [academic-years (->> (map first valid-states)
                             (distinct)
                             (sort))
-        observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 setting-2]}]
-                               (if (or (= setting-1 c/non-send)
+        observations (reduce (fn [coll {:keys [academic-year-1 need-1 need-2 setting-1 setting-2]}]
+                               (if (or (= setting-1 c/non-send) ; leaver or joiner
                                        (= setting-2 c/non-send))
                                  coll
-                                 (if (not= setting-1 setting-2)
+                                 (if (not (and (= setting-1 setting-2) ; not a remainer
+                                               (= need-1 need-2)))
                                    (update-in coll [academic-year-1 (s/join-need-setting need-1 setting-1) :alpha] m/some+ 1)
                                    (update-in coll [academic-year-1 (s/join-need-setting need-1 setting-1) :beta] m/some+ 1))))
                              {} transitions)
-
         prior-per-year (reduce (fn [coll [ay need-setting-betas]]
                                  (let [betas (apply merge-with + (vals need-setting-betas))
                                        alpha (+ (get betas :alpha 0) 0.5)
@@ -149,21 +138,22 @@
                                    (assoc coll ay {:alpha (double (/ alpha total))
                                                    :beta (double (/ beta total))})))
                                {} observations)
-        prior-per-year (continue-for-latter-ays prior-per-year academic-years)
         unobserved-priors (reduce (fn [coll ay]
                                     (if (nil? (get observations ay))
                                       (assoc coll ay {:alpha 1 :beta 1}) ; these prior values need tweaking
                                       coll)) 
                                   {} academic-years)]
     (reduce (fn [coll [ay need-setting]]
-              (if (any-valid-transitions? need-setting valid-transitions)
+              (let [[_ setting] (s/split-need-setting need-setting)
+                    aged-on-valid-settings (get valid-year-settings (inc ay))]
+                (if (get aged-on-valid-settings setting)
                 (if-let [beta-params (merge-with +
                                                  (get-in observations [ay need-setting])
                                                  (get prior-per-year ay)
                                                  (get unobserved-priors ay))]
                   (assoc coll [ay need-setting] beta-params)
                   coll)
-                coll))
+                coll)))
             {} valid-states)))
 
 (defn alpha-params-joiners
@@ -182,33 +172,49 @@
   An :NONSEND-NONSEND can be shorted to :NONSEND
   The ay_n+1 can be ommitted and assumed."
   [valid-states transitions]
-  (let [by-ay (-> transitions
-                  (select-transitions joiner?)
+  (let [joiner-transitions (-> transitions (select-transitions joiner?))
+        number-of-unique-joiner-transitions (reduce (fn [c r] (+ c (second r))) 0 joiner-transitions)
+        by-ay (-> joiner-transitions
                   (alpha-params (juxt academic-year state-2)))
         academic-years (->> valid-states (map first) distinct sort)
-        params (reduce (fn [coll ay]
+        dirichlet (reduce (fn [coll ay]
                          (let [valid-states (s/validate-states-for-ay valid-states ay)
                                prior-alphas (zipmap valid-states (repeat (/ 1.0 (count valid-states))))]
                            (if-let [v (get by-ay ay)]
                              (assoc coll ay (merge-with + prior-alphas v))
-                             coll)))
+                                ; no observed prior
+                                (assoc coll ay prior-alphas))))
                        {}
-                       academic-years)]
-    (continue-for-latter-ays params academic-years)))
+                          academic-years)
+        dirichlet-parameter-space-size (reduce (fn [c row] (+ c (count (second row)))) 0 dirichlet)]
+    (println (str "\nnumber-of-unique-joiner-transitions: " number-of-unique-joiner-transitions))
+    (println (str "joiner-dirichlet-parameter-space-size:" dirichlet-parameter-space-size))
+    (println (str "joiner-percentage-of-dirichlet-using-only-priors: " (- 100 (double (* 100 (/ number-of-unique-joiner-transitions dirichlet-parameter-space-size))))))
+    dirichlet))
 
+(defn cart [colls]
+  (if (empty? colls)
+    '(())
+    (for [x (first colls)
+          more (cart (rest colls))]
+      (into [] (cons x more)))))
 
 (defn- mover-alpha-prior
   "Calculate prior by adding uniform distribution across allowed settings to observations and normalising."
-  [need-setting valid-transitions valid-settings observations-per-ay ay]
+  [need-setting valid-transitions valid-settings aged-on-valid-settings valid-needs observations-per-ay ay]
   (let [[need setting] (s/split-need-setting need-setting)
         allowed-settings (set/intersection (set (get valid-settings [ay need]))
-                                           (set (get valid-transitions setting)))
-        prior (as-> allowed-settings s
-                (zipmap s (repeat (/ 1.0 (count allowed-settings))))
-                (merge-with + (get observations-per-ay ay) s)
-                (dissoc s setting))
+                                           (set (get valid-transitions setting))
+                                           aged-on-valid-settings)
+        allowed-needs (get valid-needs [ay setting])
+        allowed-need-settings (cart [allowed-needs allowed-settings])
+        prior (as-> allowed-need-settings s
+                    (zipmap s (repeat (/ 1.0 (count allowed-need-settings))))
+                    (into {} (for [[[need setting] v] s]
+                               [[need setting] (+ (get-in observations-per-ay [ay setting] 0) v)]))
+                    (dissoc s [need setting]))
         total (reduce + (vals prior))]
-    (reduce (fn [coll [setting v]]
+    (reduce (fn [coll [[need setting] v]]
               (assoc coll (s/join-need-setting need setting) (double (/ v total))))
             {}
             prior)))
@@ -231,25 +237,44 @@
 
 (defn alpha-params-movers
   "calculates the rate of transitions to a new state at academic year X for state Y"
-  [valid-states valid-transitions transitions]
-  (let [mover-transitions (remove (fn [{:keys [setting-1 setting-2]}]
+  [valid-states valid-year-settings valid-transitions transitions]
+  (let [mover-transitions (remove (fn [{:keys [setting-1 setting-2 need-1 need-2]}]
                                     (or (= setting-1 c/non-send)
                                         (= setting-2 c/non-send)
-                                        (= setting-1 setting-2)))
+                                        (and (= setting-1 setting-2)
+                                             (= need-1 need-2))))
                                   transitions)
+        number-of-mover-transitions (count mover-transitions)
+        number-of-unique-mover-transitions (count (group-by (juxt :setting-1 :need-1
+                                                                  :academic-year-1 :setting-2
+                                                                  :need-2 :academic-year-2) mover-transitions))
         observations (reduce (fn [coll {:keys [academic-year-1 need-1 setting-1 need-2 setting-2]}]
                                (update-in coll [academic-year-1
                                                 (s/join-need-setting need-1 setting-1)
                                                 (s/join-need-setting need-2 setting-2)] m/some+ 1))
                              {} mover-transitions)
-        valid-settings (s/calculate-valid-settings-for-need-ay valid-states)]
-    (reduce (fn [coll [ay need-setting]]
+        valid-settings (s/calculate-valid-settings-for-need-ay valid-states)
+        valid-needs (s/calculate-valid-needs-for-setting-ay valid-states)
+        dirichlet (reduce (fn [coll [ay need-setting]]
+                            (let [[_ setting] (s/split-need-setting need-setting)
+                                  aged-on-valid-settings (get valid-year-settings (inc ay))]
+                              (if (get aged-on-valid-settings setting)
               (let [obs-for-ay (get-in observations [ay need-setting])
                     prior (mover-alpha-prior need-setting
                                              valid-transitions
                                              valid-settings
+                                                               aged-on-valid-settings
+                                                               valid-needs
                                              (mover-observations-per-ay valid-states mover-transitions)
                                              ay)]
-                (assoc coll [ay need-setting] (merge-with + prior obs-for-ay))))
+                                  (assoc coll [ay need-setting] (merge-with + prior obs-for-ay)))
+                                coll)))
             {}
-            valid-states)))
+                          valid-states)
+        dirichlet-parameter-space-size (reduce (fn [c row] (+ c (count (second row)))) 0 dirichlet)]
+    (println (str "\nnumber-of-mover-transitions:" number-of-mover-transitions))
+    (println (str "number-of-unique-mover-transitions: " number-of-unique-mover-transitions))
+    (println (str "dirichlet-parameter-space-size:" dirichlet-parameter-space-size))
+    (println (str "percentage-of-dirichlet-using-only-priors: " (- 100 (double (* 100 (/ number-of-unique-mover-transitions dirichlet-parameter-space-size))))))
+    dirichlet
+    ))

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -42,9 +42,16 @@
        (map (fn [[ay' state]] state))))
 
 (defn calculate-valid-settings-for-need-ay [valid-states]
-  (reduce (fn [coll [ay state]]
-            (let [[need setting] (split-need-setting state)]
+  (let [vs (reduce (fn [coll [ay need-setting]]
+                     (let [[need setting] (split-need-setting need-setting)]
               (update coll [ay need] (fnil conj #{}) setting)))
+                   {} valid-states)]
+    vs))
+
+(defn calculate-valid-needs-for-setting-ay [valid-states]
+  (reduce (fn [coll [ay need-setting]]
+            (let [[need setting] (split-need-setting need-setting)]
+              (update coll [ay setting] (fnil conj #{}) need)))
           {} valid-states))
 
 (defn aggregate-setting->setting [setting setting->setting]
@@ -77,3 +84,9 @@
 (defn can-move? [valid-year-settings academic-year state]
   (let [[need setting] (split-need-setting state)]
     (pos? (count (disj (get valid-year-settings (inc academic-year)) setting)))))
+
+(defn capable-of-moving?
+  "All entities are capable of moving as need movement is unrestricted except in the last possible year
+  when everyone must leave"
+  [ay]
+  (< ay c/max-academic-year))

--- a/test/witan/send/params_test.clj
+++ b/test/witan/send/params_test.clj
@@ -54,7 +54,7 @@
 
   (testing "Positive mover state alphas for every year with >1 setting"
     (let [transitions {}
-          params (sut/alpha-params-movers valid-states valid-transitions transitions)]
+          params (sut/alpha-params-movers valid-states valid-year-settings valid-transitions transitions)]
       (is (empty? (remove (fn [[academic-year state]]
                             (let [alphas (get params [academic-year state])]
                               (and (pos? (count alphas))
@@ -74,7 +74,7 @@
 
   (testing "Positive mover beta params for every valid state"
     (let [transitions {}
-          params (sut/beta-params-movers valid-states valid-transitions transitions)]
+          params (sut/beta-params-movers valid-states valid-year-settings transitions)]
       (is (every? (fn [[_ betas]]
                     (and (pos? (:alpha betas))
                          (pos? (:beta betas))))


### PR DESCRIPTION
Here's a summary of the changes I've made needed to get a very small
transitions data set producing sensible results. The impact on client
data runs seems small.

I'd like to go over these changes and get agreement that the results
are correct and then establish unit tests for the various distro
calculations and acceptance tests over some small data sets.

* ~~adds output transition data as a CSV~~
* changes transition data to use the ay "from" in the transition
  output (for consistency with input transitions)
* remainers that would have aged to invalid group and then be removed
  via the cleanup are now explicitly prevented and added to the
  transitions file as leavers
* ~~fixed a joiner beta calculation bug in which no observed joiners
  also means we also don't count the number of non-joiners for a
  calendar year~~
* ~~added unobserved priors for mover beta distribution (rather than
  fall back to kixi.stats default)~~
* ~~added unobserved priors for leaver beta distribution (rather than
  fall back to kixi.stats default)~~
* added needs to the mover dirichlet prior calculation
* fixed mover distribution calculations to allow the possibility of
  transitioning between need within the same setting.