### PR TITLE
Bug/setting transition restriction

### DIFF
--- a/src/clj/witan/send/model/output.clj
+++ b/src/clj/witan/send/model/output.clj
@@ -92,7 +92,7 @@
 (defn output-transitions-csv
   [dir filename projections simulations]
   (with-open [writer (io/writer (io/file (str dir "/" filename ".csv")))]
-    (let [columns [:calendar-year :setting-1 :need-1 :academic-year-1 :setting-2 :need-2 :academic-year-2 :avg-number-of]
+    (let [columns [:calendar-year :academic-year-1 :setting-1 :need-1 :academic-year-2 :setting-2 :need-2 :avg-number-of]
           headers (mapv name columns)
           parse-need-setting #(map name ((comp reverse states/split-need-setting) %))
           rows (sort (remove empty?

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -90,6 +90,7 @@
 (defn prep-inputs [initial-send-pop validate-valid-states valid-transitions transitions
                    transitions-filtered population valid-states original-transitions costs]
   (let [start-map {:population-by-state initial-send-pop
+                   :valid-transitions valid-transitions
                    :valid-states valid-states
                    :transitions original-transitions
                    :population population

--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -63,9 +63,6 @@
             {}
             population)))
 
-(defn any-valid-transitions? [state valid-transitions]
-  (< 1 (count (get valid-transitions (second (s/split-need-setting state))))))
-
 (defn beta-params-leavers [valid-states transitions]
   (let [academic-years (->> (map first valid-states)
                             (distinct)
@@ -88,7 +85,7 @@
         unobserved-priors (reduce (fn [coll ay]
                                     (if (nil? (get observations ay))
                                       (assoc coll ay {:alpha 0.5 :beta 0.5}) ; these prior values need tweaking
-                                      coll)) 
+                                      coll))
                                   {} academic-years)]
     (reduce (fn [coll [ay state]]
               (if-let [beta-params (merge-with +
@@ -153,10 +150,10 @@
         unobserved-priors (reduce (fn [coll ay]
                                     (if (nil? (get observations ay))
                                       (assoc coll ay {:alpha 1 :beta 1}) ; these prior values need tweaking
-                                      coll)) 
+                                      coll))
                                   {} academic-years)]
     (reduce (fn [coll [ay need-setting]]
-              (if (any-valid-transitions? need-setting valid-transitions)
+              (if (s/any-valid-transitions? need-setting valid-transitions)
                 (if-let [beta-params (merge-with +
                                                  (get-in observations [ay need-setting])
                                                  (get prior-per-year ay)

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -74,6 +74,10 @@
             {}
             (range minimum-academic-year (inc maximum-academic-year)))))
 
-(defn can-move? [valid-year-settings academic-year state]
+(defn any-valid-transitions? [state valid-transitions]
+  (< 1 (count (get valid-transitions (second (split-need-setting state))))))
+
+(defn can-move? [valid-year-settings academic-year state valid-transitions]
   (let [[need setting] (split-need-setting state)]
-    (pos? (count (disj (get valid-year-settings (inc academic-year)) setting)))))
+    (and (any-valid-transitions? (join-need-setting need setting) valid-transitions)
+         (pos? (count (disj (get valid-year-settings (inc academic-year)) setting))))))

--- a/test/witan/send/params_test.clj
+++ b/test/witan/send/params_test.clj
@@ -61,7 +61,8 @@
                                    (->> alphas vals (every? pos?)))))
                           (for [academic-year c/academic-years
                                 state (s/validate-states-for-ay valid-states academic-year)
-                                :when (s/can-move? valid-year-settings academic-year state)]
+                                :when (s/can-move? valid-year-settings academic-year
+                                                   state valid-transitions)]
                             [academic-year state]))))))
 
   (testing "Positive leaver beta params for every valid state"

--- a/test/witan/send/states_test.clj
+++ b/test/witan/send/states_test.clj
@@ -17,6 +17,7 @@
 (deftest can-move-test
   (let [[path schema] (:valid-states (test-inputs))
         data (ds/row-maps (i/csv-to-dataset path schema))
-        valid-year-settings (calculate-valid-year-settings-from-setting-academic-years data)]
+        valid-year-settings (calculate-valid-year-settings-from-setting-academic-years data)
+        valid-transitions (calculate-valid-mover-transitions data)]
     (testing ""
-      (is (true? (can-move? valid-year-settings 0 :CL-MSS))))))
+      (is (true? (can-move? valid-year-settings 0 :L-A valid-transitions))))))


### PR DESCRIPTION
The setting->setting data in the valid-states files is supposed to inform which transitions are and aren't possible. However when entering no settings in a cell, no rate is calculated but the transitions are still possible during a projection.

The `any-valid-transitions?` is still not ideal in it's implementation, but it at least creates a situation where is setting->setting is empty, then people can't move from that setting and it already existed.