### PR TITLE
Make a setting invalid

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -71,6 +71,10 @@ The more keys/entities used the more specific the set of transitions to be modif
 
 A further additional, required key in each map is `:modify-transitions-by`, which should include a value corresponding to a number (integer or float) by which to multiply the count of transitions corresponding to the entity keys with which to filter on. For example a value of `2` here would double the number of transition of a specific type, and `0.5` would half them.
 
+##### `:making-setting-invalid`
+
+Expects a setting as a key (i.e. `:OE`), corresponding to the setting to make future movement invalid to.
+
 ### `:projection-parameters`
 
 Contains two required keys for every projection.

--- a/doc/scenarios.md
+++ b/doc/scenarios.md
@@ -35,3 +35,8 @@ Here each scenario projection is simply defined in terms of the collection of pa
 * Parameters = `:modify-transitions-from` and `:transitions-to-change
 * Arguments = as with above scenario, and additionally a calendar year (`2020`) from when a user may wish to apply the new transition rates
 * An [example](https://gist.github.com/seb231/0218cb773df526e4e99b992db028703d) may be that a user only wants to start modelling a transition rate policy change in three years time and maintain the current trends until that time
+
+### _“Make a setting invalid”_
+
+* Parameters = `:make-setting-invalid` and `:transitions-to-change`
+* Arguments = `:make-setting-invalid` expects a setting name as a key and `:transitions-to-change` must take a map whereby `:setting-2` equals the setting to make invalid and `:modify-transition-by` equals `0`.

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -194,7 +194,7 @@
   [{:keys [transitions population
            costs valid-states]}
    {:keys [which-transitions? transitions-to-change
-           filter-transitions-from]}]
+           filter-transitions-from make-setting-invalid]}]
   (run-input-checks (ds/row-maps transitions)
                     (ds/row-maps costs)
                     (ds/row-maps valid-states))
@@ -254,4 +254,5 @@
                                          valid-transitions modified-transitions
                                          transitions-filtered population valid-states
                                          original-transitions costs))
-     :seed-year (inc max-transition-year)}))
+     :seed-year (inc max-transition-year)
+     :make-setting-invalid make-setting-invalid}))


### PR DESCRIPTION
Allows one to set a specific setting to make it invalid, so everyone in that setting must leave SEND in their next transition