### PR TITLE
More explicit and faster send run

### DIFF
--- a/src/clj/witan/send/model/data_products.clj
+++ b/src/clj/witan/send/model/data_products.clj
@@ -1,0 +1,193 @@
+(ns witan.send.model.data-products
+  (:require [witan.send.constants :as constants]
+            [witan.send.maths :as m]
+            [witan.send.schemas :as sc]
+            [witan.send.states :as states]
+            [witan.send.utils :as u])
+  (:import org.HdrHistogram.IntCountsHistogram))
+
+(def number-of-significant-digits 3)
+
+(defn roll-up-calendar-year-by-need-setting [calendar-year]
+  (transduce
+   (map (fn [[[ay need-setting] population]] [need-setting population]))
+   (fn
+     ([totals] totals)
+     ([totals [need-setting population]]
+      (update totals need-setting m/some+ population)))
+   {}
+   calendar-year))
+
+(defn roll-up-calendar-year-by-state [all-valid-states calendar-year]
+  (reduce
+   (fn [acc state]
+     (assoc acc state (get calendar-year state 0)))
+   {}
+   all-valid-states))
+
+(defn roll-up-calendar-year-by-ay [calendar-year]
+  (reduce
+   (fn [acc [[ay need-setting] pop]]
+     (update acc ay + pop)) ;; can be + b/c we shouldn't have pops to add outside of the known academic years
+   (into (sorted-map) (map vector sc/academic-years (repeat 0)))
+   calendar-year))
+
+(defn roll-up-calendar-year-by-total-send-population [calendar-year]
+  (transduce
+   (remove (fn [[[ay need-setting] population]]
+             (= need-setting constants/non-send)))
+   (fn
+     ([total] total)
+     ([total [[ay need-setting] population]] (update total :total-population + population)))
+   {:total-population 0}
+   calendar-year))
+
+(defn roll-up-calendar-year-by-total-in-send-by-need [calendar-year]
+  (transduce
+   (map (fn [[[ay need-setting] population]]
+          [(-> need-setting
+               (states/split-need-setting)
+               first)
+           population]))
+   (fn
+     ([totals] totals)
+     ([totals [need population]]
+      (update totals need m/some+ population)))
+   {}
+   calendar-year))
+
+(defn roll-up-calendar-year-by-total-in-send-by-setting [calendar-year]
+  (transduce
+   (map (fn [[[ay need-setting] population]]
+          [(-> need-setting
+               (states/split-need-setting)
+               second)
+           population]))
+   (fn
+     ([totals] totals)
+     ([totals [setting population]]
+      (update totals setting m/some+ population)))
+   {}
+   calendar-year))
+
+(defn roll-up-calendar-year-by-total-cost [cost-lookup calendar-year]
+  (transduce
+   (comp
+    (remove (fn [[[ay need-setting] population]]
+              (= need-setting constants/non-send))) ;; remove non-send
+    ;; convert need-setting population to need-setting cost
+    (map (fn [[[ay need-setting] population]] [need-setting population]))
+    (map (fn [[need-setting population]] [(states/split-need-setting need-setting) population]))
+    (map (fn [[need-setting population]] [need-setting
+                                          (* (get cost-lookup need-setting 0)
+                                             population)]))
+    (map (fn [[need-setting cost]] cost)))
+   (fn
+     ([total] total)
+     ([total cost] (update total :total-cost + cost)))
+   {:total-cost 0.0}
+   calendar-year))
+
+(defn roll-up-total-in-send-by-ay-group [calendar-year]
+  (transduce
+   (comp
+    (map (fn [[[ay need-setting] population]] [ay population]))
+    (map (fn [[ay population]] [(u/ay-groups ay) population])))
+   (fn
+     ([totals] totals)
+     ([totals [ay-group population]]
+      (update totals ay-group m/some+ population)))
+   {}
+   calendar-year))
+
+(defn histogram-summary-rf
+  ([] (transient {:simulation-years (repeat {})
+                  :number-of-simulations 0}))
+  ([{:keys [simulation-years number-of-simulations] :as acc} new-simulation-years]
+   (assoc! acc
+           :simulation-years
+           (into []
+                 (map
+                  (fn [[^IntCountsHistogram histogram ^IntCountsHistogram new-histogram]]
+                    (merge-with
+                     (fn [^IntCountsHistogram histogram ^IntCountsHistogram new-histogram]
+                       (if histogram
+                         (doto histogram (.add new-histogram))
+                         new-histogram))
+                     histogram
+                     new-histogram)))
+                 (sequence (map (fn [x1 x2] [x1 x2]))
+                           simulation-years
+                           new-simulation-years))
+           :number-of-simulations (inc number-of-simulations)))
+  ([{:keys [simulation-years ^int number-of-simulations]}]
+   (into []
+         (map
+          (fn [year]
+            (into {}
+                  (map (fn [[k ^IntCountsHistogram histogram]]
+                         [k (let [result {:median (dec (.getValueAtPercentile histogram 50.0))
+                                          :mean (dec (.getMean histogram))
+                                          :std-dev (.getStdDeviation histogram)
+                                          :iqr (- (.getValueAtPercentile histogram 75.0) (.getValueAtPercentile histogram 25.0))
+                                          :min (dec (.getValueAtPercentile histogram 0.0))
+                                          :max (dec (.getValueAtPercentile histogram 100.0))
+                                          :q1 (dec (.getValueAtPercentile histogram 25.0))
+                                          :q3 (dec (.getValueAtPercentile histogram 75.0))
+                                          :low-95pc-bound (dec (.getValueAtPercentile histogram 2.5))
+                                          :high-95pc-bound (dec (.getValueAtPercentile histogram 97.5))}]
+                              (u/confidence-intervals result number-of-simulations))]))
+                  year)))
+         simulation-years)))
+
+(defn rolled-up-simulations-with-n-to-simulations-with-histograms [rollup-fn]
+  (map (fn [simulation]
+         (into []
+               (comp
+                (map :model)
+                (map rollup-fn)
+                (map (fn [year]
+                       (into {}
+                             (map (fn [[k n]]
+                                    [k (let [hist (IntCountsHistogram. number-of-significant-digits)]
+                                         (doto hist (.recordValue (inc n))))]))
+                             year))))
+               simulation))))
+
+(defn summarise-results [rollup-fn projections]
+  (transduce
+   (comp
+    (rolled-up-simulations-with-n-to-simulations-with-histograms rollup-fn))
+   histogram-summary-rf
+   projections))
+
+(defn data-products [valid-states cost-lookup simulations]
+  (let [by-state (future (summarise-results
+                          (partial roll-up-calendar-year-by-state
+                                   (states/calculate-valid-states-from-setting-academic-years valid-states))
+                          simulations))
+        total-in-send-by-ay (future (summarise-results roll-up-calendar-year-by-ay simulations))
+        total-in-send (future (into []
+                                    (map :total-population)
+                                    (summarise-results roll-up-calendar-year-by-total-send-population simulations)))
+        total-in-send-by-need (future (summarise-results roll-up-calendar-year-by-total-in-send-by-need simulations))
+        total-in-send-by-setting (future (summarise-results roll-up-calendar-year-by-total-in-send-by-setting simulations))
+        total-cost (future (into []
+                                 (map :total-cost)
+                                 (summarise-results (partial roll-up-calendar-year-by-total-cost cost-lookup)
+                                                    simulations)))
+        total-in-send-by-ay-group (future (summarise-results roll-up-total-in-send-by-ay-group simulations))
+        ]
+    {:by-state @by-state
+     :total-in-send-by-ay @total-in-send-by-ay
+     :total-in-send @total-in-send
+     :total-in-send-by-need @total-in-send-by-need
+     :total-in-send-by-setting @total-in-send-by-setting
+     :total-cost @total-cost
+     :total-in-send-by-ay-group @total-in-send-by-ay-group}))
+
+(defn ->send-output-style [data-products]
+  (let [data-keys (keys data-products)]
+    (into []
+          (map #(zipmap data-keys %))
+          (apply map vector ((apply juxt data-keys) data-products)))))

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -6,7 +6,7 @@
             [witan.send.schemas :as sc]
             [witan.send.states :as states]
             [witan.send.step :as step]
-            [witan.send.utils :as u]))
+            [witan.send.model.data-products :as dp]))
 
 (defn incorporate-new-ay-need-setting-populations
   "Take a model + transitions tuple as its first argument.
@@ -156,37 +156,22 @@
   [projections]
   (apply merge-with + (mapcat #(map :transitions %) projections)))
 
-(defn values-rf
-  "Associate a reducing function to be used for each value of map indexed by key"
-  [kvs]
-  (->> (for [[k v] kvs]
-         [k (r/pre-step v k)])
-       (into {})
-       (r/fuse)))
+(defn projected-future-pop-by-year [projected-population seed-year]
+  (->> projected-population
+       (filter (fn [[k _]] (> k seed-year)))
+       (sort-by key)))
 
-(def number-of-significant-digits 3)
-
-(defn reduce-rf [iterations validate-valid-states cost-lookup]
-  (u/partition-rf iterations
-                  (r/fuse {:by-state (u/model-states-rf validate-valid-states (u/histogram-rf number-of-significant-digits))
-                           :total-in-send-by-ay (r/pre-step (u/with-keys-rf (u/histogram-rf number-of-significant-digits) sc/academic-years) u/model-population-by-ay)
-                           :total-in-send (r/pre-step (u/histogram-rf number-of-significant-digits) u/model-send-population)
-                           :total-in-send-by-need (r/pre-step (u/merge-with-rf (u/histogram-rf number-of-significant-digits)) u/model-population-by-need)
-                           :total-in-send-by-setting (r/pre-step (u/merge-with-rf (u/histogram-rf number-of-significant-digits)) u/model-population-by-setting)
-                           :total-cost (r/pre-step (u/histogram-rf number-of-significant-digits) (comp (partial u/total-need-setting-cost cost-lookup)
-                                                                                                       u/model-population-by-need-setting))
-                           :total-in-send-by-ay-group (r/pre-step (u/merge-with-rf (u/histogram-rf number-of-significant-digits))
-                                                                  u/model-population-by-ay-group)})))
-
-(defn combine-rf [simulations iterations]
-  (u/partition-rf iterations
-                  (values-rf {:by-state (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
-                              :total-in-send-by-ay (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
-                              :total-in-send (u/histogram-combiner-rf simulations number-of-significant-digits)
-                              :total-in-send-by-need (u/merge-with-rf (u/histogram-combiner-rf simulations  number-of-significant-digits))
-                              :total-in-send-by-setting (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))
-                              :total-cost (u/histogram-combiner-rf simulations number-of-significant-digits)
-                              :total-in-send-by-ay-group (u/merge-with-rf (u/histogram-combiner-rf simulations number-of-significant-digits))})))
+(defn create-projections [simulations modify-transitions-from make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
+  (sequence
+   (map (fn [simulation-run]
+          (reductions (partial run-model-iteration
+                               modify-transitions-from
+                               make-setting-invalid
+                               inputs
+                               modified-inputs)
+                      {:model population-by-state}
+                      (projected-future-pop-by-year projected-population seed-year))))
+   (range simulations)))
 
 (defn run-send-model
   "Outputs the population for the last year of historic data, with one
@@ -202,35 +187,18 @@
         modified-inputs (when ((complement nil?) scenario-projection)
                           (assoc scenario-projection :valid-year-settings
                                  (states/calculate-valid-year-settings-from-setting-academic-years valid-states)))
-        projected-future-pop-by-year (->> projected-population
-                                          (filter (fn [[k _]] (> k seed-year)))
-                                          (sort-by key))
-        iterations (inc (count projected-future-pop-by-year)) ;; include current year
-        validate-valid-states (states/calculate-valid-states-from-setting-academic-years valid-states)
         inputs (assoc inputs :valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years valid-states))
-        projections (->> (range simulations)
-                         ;; The logic is for validation compatibility only, elsewise we could just use the truth expression
-                         (partition-all (if (< simulations 8)
-                                          (int (Math/ceil (/ simulations 8)))
-                                          (int (/ simulations 8))))
-                         (pmap (fn [simulations]
-                                 (->> (for [_ simulations]
-                                        (let [projection (reductions (partial run-model-iteration modify-transitions-from make-setting-invalid
-                                                                              inputs modified-inputs)
-                                                                     {:model population-by-state}
-                                                                     projected-future-pop-by-year)]
-                                          projection))
-                                      (doall))))
-                         (doall))
-        reduced (doall
-                 (for [projection projections]
-                   (do (println "Reducing...")
-                       (transduce (map #(map :model %)) (reduce-rf iterations validate-valid-states cost-lookup) projection))))
-        projection (apply concat projections)]
-    (println "Combining...")
+        projection (create-projections simulations
+                                       modify-transitions-from
+                                       make-setting-invalid
+                                       inputs
+                                       modified-inputs
+                                       population-by-state
+                                       projected-population
+                                       seed-year)]
     {:projection (projection->transitions projection)
      :simulations simulations
-     :send-output (transduce identity (combine-rf simulations iterations) reduced)
+     :send-output (dp/->send-output-style (dp/data-products valid-states cost-lookup projection))
      :transitions transitions
      :valid-states valid-states
      :population population

--- a/src/clj/witan/send/utils.clj
+++ b/src/clj/witan/send/utils.clj
@@ -1,45 +1,5 @@
 (ns witan.send.utils
-  (:require [kixi.stats.math :as math]
-            [medley.core :as medley]
-            [witan.send.constants :as c]
-            [witan.send.maths :as m]
-            [witan.send.states :as states])
-  (:import org.HdrHistogram.IntCountsHistogram))
-
-(defn model-population-by-ay
-  [model]
-  (reduce (fn [coll [[ay state] population]]
-            (cond-> coll
-              (not= state c/non-send)
-              (update ay m/some+ population)))
-          {} model))
-
-(defn model-population-by-need
-  [model]
-  (reduce (fn [coll [[ay state] population]]
-            (let [[need setting] (states/split-need-setting state)]
-              (cond-> coll
-                (not= state c/non-send)
-                (update need m/some+ population))))
-          {} model))
-
-(defn model-population-by-setting
-  [model]
-  (reduce (fn [coll [[ay state] population]]
-            (let [[need setting] (states/split-need-setting state)]
-              (cond-> coll
-                (not= state c/non-send)
-                (update setting m/some+ population))))
-          {} model))
-
-(defn model-population-by-need-setting
-  [model]
-  (reduce (fn [coll [[ay state] population]]
-            (let [[need setting] (states/split-need-setting state)]
-              (cond-> coll
-                (not= state c/non-send)
-                (update [need setting] m/some+ population))))
-          {} model))
+  (:require [kixi.stats.math :as math]))
 
 (defn ay-groups [ay]
   (condp >= ay
@@ -49,39 +9,7 @@
     13 "NCY 12-13"
     "NCY 14+"))
 
-(defn model-population-by-ay-group
-  [model]
-  (reduce (fn [coll [[ay state] population]]
-            (let [ay-group (ay-groups ay)]
-              (cond-> coll
-                (not= state c/non-send)
-                (update ay-group m/some+ population))))
-          {} model))
-
-(defn total-need-setting-cost
-  [need-setting-lookup population-by-need-setting]
-  (-> (reduce (fn [cost [split-need-setting population]]
-                (+ cost (* population (get need-setting-lookup split-need-setting 0))))
-              0 population-by-need-setting)
-      m/round))
-
-(defn model-send-population
-  [model]
-  (reduce (fn [n [[ay state] population]]
-            (cond-> n
-              (not= state c/non-send)
-              (+ population)))
-          0 model))
-
 ;;;; Reducing functions for use with transduce
-
-(defn histogram-rf
-  [number-of-significant-digits]
-  (fn
-    ([] (IntCountsHistogram. number-of-significant-digits))
-    ([hist x]
-     (doto hist (.recordValue (inc x))))
-    ([hist] hist)))
 
 (defn confidence-intervals [m sims]
   (let [z-value 1.96 ;; this is for a 95% confidence value assuming normal distribution
@@ -89,80 +17,3 @@
         margin-of-error (* z-value std-err)]
     (merge m {:low-ci (- (:mean m) margin-of-error)
               :high-ci (+ (:mean m) margin-of-error)})))
-
-(defn histogram-combiner-rf
-  [simulations number-of-significant-digits]
-  (fn
-    ([] (IntCountsHistogram. number-of-significant-digits))
-    ([acc hist]
-     (doto acc (.add hist)))
-    ([hist]
-     (let [result {:median (dec (.getValueAtPercentile hist 50.0))
-                   :mean (dec (.getMean hist))
-                   :std-dev (.getStdDeviation hist)
-                   :iqr (- (.getValueAtPercentile hist 75.0) (.getValueAtPercentile hist 25.0))
-                   :min (dec (.getValueAtPercentile hist 0.0))
-                   :max (dec (.getValueAtPercentile hist 100.0))
-                   :q1 (dec (.getValueAtPercentile hist 25.0))
-                   :q3 (dec (.getValueAtPercentile hist 75.0))
-                   :low-95pc-bound (dec (.getValueAtPercentile hist 2.5))
-                   :high-95pc-bound (dec (.getValueAtPercentile hist 97.5))}]
-       (confidence-intervals result simulations)))))
-
-(defn merge-with-rf
-  "Like (apply merge-with f) but for reducing functions"
-  [rf]
-  (fn
-    ([] {})
-    ([acc x]
-     (reduce (fn [acc [k v]]
-               (-> acc
-                   (cond-> (not (contains? acc k))
-                     (assoc k (rf)))
-                   (update k rf v)))
-             acc x))
-    ([acc]
-     (medley/map-vals rf acc))))
-
-(defn model-states-rf
-  [valid-states rf]
-  (fn
-    ([]
-     (reduce (fn [coll k]
-               (assoc coll k (rf)))
-             {} valid-states))
-    ([acc x]
-     (medley/map-kv
-      (fn [k v]
-        [k (rf v (get x k 0))])
-      acc))
-    ([acc]
-     (medley/map-vals rf acc))))
-
-(defn with-keys-rf
-  [rf keys]
-  (fn
-    ([]
-     (reduce (fn [coll k]
-               (assoc coll k (rf)))
-             {} keys))
-    ([acc x]
-     (medley/map-kv
-      (fn [k v]
-        [k (rf v (get x k 0))])
-      acc))
-    ([acc]
-     (medley/map-vals rf acc))))
-
-(defn partition-rf
-  "Executes the rf on partitions of length n, returning n results"
-  [n rf]
-  (fn
-    ([]
-     (println "Initialising...")
-     (mapv #(%1) (repeat n rf)))
-    ([acc xs]
-     (mapv #(rf %1 %2) acc xs))
-    ([acc]
-     (println "Complete rf...")
-     (mapv #(rf %1) acc))))


### PR DESCRIPTION
The existing send run code was difficult to follow and debug, and the expensive reduce portion ran single threaded while the cheaper simulation bit was multi-threaded. 

This PR swaps this around. Get rid of the pmap, runs each reducing function in its own future and has explicit code for each data product produced in the reduce step.

There are some data shape dependencies based on how the old code used the reducing function composition that should be factored out in the future, but I think this is a simplification of what was there before with the advantage of being a bit faster to run as well.

witan.send.data-products replaces the roll up and calculate functions in witan.send.util `model-population-by-*` and the `reduce-rf` and `combine-rf` functions in witan.send.run. It makes it a bit easier to run each one in a future and possibly later by allowing us to create a data pipeline using core.async so that we can add more ways of re-purposing the simulation data.