### PR TITLE
Kondo fixes

### DIFF
--- a/src/clj/witan/send/check_inputs.clj
+++ b/src/clj/witan/send/check_inputs.clj
@@ -1,21 +1,19 @@
 (ns witan.send.check-inputs
-  (:require [witan.send.report :as r]
-            [witan.send.utils :as u]))
-
+  (:require [witan.send.report :as r]))
 
 (defn repl-warn [& args]
   (println (str "\u001B[1;31m" (apply str args) "\u001B[m")))
 
-
-(defn find-states [need setting academic-year transition]
+(defn find-states
   "Takes :need and :setting key and returns map containing values from transition data"
+  [need setting academic-year transition]
   (if (= :NONSEND (need transition))
     :NONSEND
     {:need (need transition) :setting (setting transition) :academic-year (academic-year transition)}))
 
-
-(defn set-of-input-states [transitions with-academic-year?]
+(defn set-of-input-states
   "Takes transitions and returns set containing maps of possible states"
+  [transitions with-academic-year?]
   (let [state-1s (map #(find-states :need-1 :setting-1 :academic-year-1 %) transitions)
         state-2s (map #(find-states :need-2 :setting-2 :academic-year-2 %) transitions)
         all-states (filter #(not= :NONSEND %) (concat state-1s state-2s))]
@@ -34,8 +32,9 @@
     (r/info (r/bold w))
     (repl-warn w)))
 
-(defn check-all-ages-present [transitions]
+(defn check-all-ages-present
   "Checks all ages are represented in both academic years 1 and 2"
+  [transitions]
   (let [transitions-to-ages (into #{} (map :academic-year-2 transitions))
         transitions-from-ages (into #{} (map :academic-year-1 transitions))
         all-ages (into transitions-to-ages transitions-from-ages)
@@ -49,8 +48,9 @@
                (remove (fn [a] (some #(= a %) transitions-from-ages)))
                (map #(str "There are no transitions from AY " %))))))
 
-(defn check-joiner-leaver-gaps [transitions]
+(defn check-joiner-leaver-gaps
   "bring in range of ages in dataset, check that all ages have joiners and leavers"
+  [transitions]
   (let [ages (sort (distinct (concat (map :academic-year-2 transitions) (map :academic-year-1 transitions))))]
     (into (->> ages
                (drop-last 1)
@@ -61,26 +61,30 @@
                (filter (fn [a] (empty? (filter #(leaver? a %) transitions))))
                (map #(str "There are no leavers from AY " %))))))
 
-(defn check-ages-go-up-one-year [transitions]
+(defn check-ages-go-up-one-year
   "Checks academic year 2 is always academic year 1 + 1"
+  [transitions]
   (->> transitions
        (remove (fn [t] (= (+ 1 (:academic-year-1 t)) (:academic-year-2 t))))
        (map #(str "Academic years 1 and 2 are not incremental for " %))))
 
-(defn cost-for-need-setting? [need-setting costs]
+(defn cost-for-need-setting?
   "Takes seq containing need-setting and returns true for match in costs"
+  [need-setting costs]
   (some? (some true? (map #(and (= (first need-setting) (:need %))
                                 (= (last need-setting) (:setting %))) costs))))
 
-(defn count-of-input-need-settings [transitions]
+(defn count-of-input-need-settings
   "Counts need setting pair occurrences in ay1 and ay2 cols in transitions"
+  [transitions]
   (let [need-setting-1 (map #(vals (select-keys % [:need-1 :setting-1])) transitions)
         need-setting-2 (map #(vals (select-keys % [:need-2 :setting-2])) transitions)
         all-need-settings (filter #(not= :NONSEND (first %)) (concat need-setting-1 need-setting-2))]
-      (frequencies all-need-settings)))
+    (frequencies all-need-settings)))
 
-(defn check-missing-costs [transitions costs]
+(defn check-missing-costs
   "Produces warnings for states without costs via REPL and SEND_report.md"
+  [transitions costs]
   (let [need-settings (count-of-input-need-settings transitions)]
     (->> need-settings
          (remove #(cost-for-need-setting? (first %) costs))
@@ -88,31 +92,35 @@
                     ", with " (last %) " occurrences")))))
 
 
-(defn valid-ay-for-state? [state valid-ays]
+(defn valid-ay-for-state?
   "Takes map containing state with academic year and returns true for valid states"
+  [state valid-ays]
   (some? (some true? (map #(and (= (:setting state) (:setting %))
                                 (and (>= (:academic-year state) (:min-academic-year %))
                                      (<= (:academic-year state) (:max-academic-year %))))
                           valid-ays))))
 
 
-(defn check-states-in-valid-ays [transitions valid-states]
+(defn check-states-in-valid-ays
   "Produces warnings for states that are outside valid academic years via REPL and SEND_report.md"
+  [transitions valid-states]
   (let [states (set-of-input-states transitions true)]
     (->> states
          (remove #(valid-ay-for-state? % valid-states))
          (map #(str "Invalid setting for academic year in transitions.csv: "
                     (:need %) " " (:setting %) " academic-year: " (:academic-year %))))))
 
-(defn miscoded-nonsend? [transition]
+(defn miscoded-nonsend?
   "Checks setting-n and need-n are both NONSEND"
+  [transition]
   (or (and (not= (:setting-1 transition) :NONSEND) (= (:need-1 transition) :NONSEND))
       (and (= (:setting-1 transition) :NONSEND) (not= (:need-1 transition) :NONSEND))
       (and (not= (:setting-2 transition) :NONSEND) (= (:need-2 transition) :NONSEND))
       (and (= (:setting-2 transition) :NONSEND) (not= (:need-2 transition) :NONSEND))))
 
-(defn check-nonsend-states-valid [transitions]
+(defn check-nonsend-states-valid
   "Checks setting-n and need-n are both NONSEND"
+  [transitions]
   (let [count-nonsend-errors (->> transitions
                                   (filter miscoded-nonsend?)
                                   count)]
@@ -121,8 +129,9 @@
 
 
 
-(defn run-input-checks [transitions costs valid-states]
+(defn run-input-checks
   "Takes row-maps of input CSVs and runs checks"
+  [transitions costs valid-states]
   (log-warnings (check-joiner-leaver-gaps transitions))
   (log-warnings (check-all-ages-present transitions))
   (log-warnings (check-ages-go-up-one-year transitions))

--- a/src/clj/witan/send/distributions.clj
+++ b/src/clj/witan/send/distributions.clj
@@ -9,11 +9,11 @@
 
 (defn sample-dirichlet-multinomial
   [n alphas]
-  (let [[ks as] (apply mapv vector alphas)]
-    (let [xs (if (pos? n)
-               (d/draw (d/dirichlet-multinomial n as) {:seed (get-seed!)})
-               (repeat 0))]
-      (zipmap ks xs))))
+  (let [[ks as] (apply mapv vector alphas)
+        xs (if (pos? n)
+             (d/draw (d/dirichlet-multinomial n as) {:seed (get-seed!)})
+             (repeat 0))]
+    (zipmap ks xs)))
 
 (defn sample-beta-binomial
   [n params]

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -1,6 +1,5 @@
 (ns witan.send.model.run
-  (:require [redux.core :as r]
-            [witan.send.constants :as c]
+  (:require [witan.send.constants :as c]
             [witan.send.distributions :as d]
             [witan.send.maths :as m]
             [witan.send.schemas :as sc]
@@ -56,7 +55,7 @@
   or academic year range is valid."
   [[model transitions] [[year need-setting] population]
    {:keys [mover-state-alphas mover-beta-params leaver-beta-params
-           valid-year-settings] :as params}
+           valid-year-settings]}
    calendar-year valid-transitions make-setting-invalid]
   (if-let [mover-dirichlet-params (get mover-state-alphas [(dec year) need-setting])]
     (let [leavers (if (= (second (states/split-need-setting need-setting)) make-setting-invalid)

--- a/src/clj/witan/send/report.clj
+++ b/src/clj/witan/send/report.clj
@@ -1,6 +1,5 @@
 (ns witan.send.report
   (:require [clojure.java.io :as io]
-            [witan.send.metadata :as md]
             [clojure.string :as str]))
 
 (def send-report (atom []))

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -10,7 +10,7 @@
 
 (defn build-input-datasets
   "Build a map of the datasets to use for input"
-  [project-dir {:keys [costs population settings-to-change transitions valid-states] :as file-inputs} schema-inputs]
+  [project-dir {:keys [costs population settings-to-change transitions valid-states]} schema-inputs]
   (let [input-datasets {:costs (wic/csv->costs (str project-dir "/" costs))
                         :population (wip/csv->population (str project-dir "/" population))
                         :transitions (wit/csv->transitions (str project-dir "/" transitions))

--- a/src/clj/witan/send/states.clj
+++ b/src/clj/witan/send/states.clj
@@ -32,7 +32,7 @@
 
 (defn calculate-valid-states-from-setting-academic-years
   [valid-states]
-  (for [{:keys [setting setting->group min-academic-year max-academic-year needs]} valid-states
+  (for [{:keys [setting min-academic-year max-academic-year needs]} valid-states
         need (map keyword (str/split needs #","))
         academic-year (range min-academic-year (inc max-academic-year))]
     [academic-year (join-need-setting need setting)]))

--- a/test/witan/send/check_inputs_test.clj
+++ b/test/witan/send/check_inputs_test.clj
@@ -1,6 +1,6 @@
 (ns witan.send.check-inputs-test
-  (:require [clojure.test :refer :all]
-            [witan.send.check-inputs :refer :all]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [witan.send.check-inputs :refer [check-ages-go-up-one-year check-all-ages-present check-joiner-leaver-gaps check-nonsend-states-valid cost-for-need-setting? valid-ay-for-state?]]))
 
 
 (def test-setting-costs [{:need :X, :setting :Y, :cost 999.9}])

--- a/test/witan/send/send_test.clj
+++ b/test/witan/send/send_test.clj
@@ -63,9 +63,11 @@
       (is (= 2 (get (mp/modify-transitions transitions state-change2 * 0.5) [2014 1 :NONSEND :SP-MMSIB]))))))
 
 (deftest remove-transitions-xf-test
-  "This test needs splitting to simpler cases but for speed captures most things.
-  There's some discussion to be had over how we should treat setting-2 as it moves into calendar year 2017
-  Note: the test discovered the keyname is required not a string :-("
+  ;; This test needs splitting to simpler cases but for speed captures
+  ;; most things.  There's some discussion to be had over how we
+  ;; should treat setting-2 as it moves into calendar year 2017
+  ;;
+  ;; Note: the test discovered the keyname is required not a string :-(
   (let [transitions (list {:calendar-year 2015, :setting-1 :NONSEND, :need-1 :NA, :academic-year-1 11, :setting-2 :MU, :need-2 :NA, :academic-year-2 12}
                           {:calendar-year 2015, :setting-1 :NONSEND, :need-1 :NA, :academic-year-1 11, :setting-2 :AK, :need-2 :NA, :academic-year-2 12}
                           {:calendar-year 2015, :setting-1 :NONSEND, :need-1 :NA, :academic-year-1 9, :setting-2 :AK, :need-2 :NA, :academic-year-2 10}


### PR DESCRIPTION
I've used the clj-kondo linter to highlight a number of fixes. The fall into the following categories:

1. if without a second leg
2. misplaced docstrings
3. redundant lets
4. unused namespaces
5. :refer :all

Some unused vars have been left in where they are in function calls or destructuring as they serve as documentation for the structure. clj-kondo still reports these as warnings.