### PR TITLE
goal-seek never starts lower than zero

### DIFF
--- a/src/clj/witan/send/goal_seek.clj
+++ b/src/clj/witan/send/goal_seek.clj
@@ -124,7 +124,9 @@
     (loop [configs (map update-results-path
                         (-> (create-transition-modifier-seq
                              m
-                             (- initial-modifier 1)
+                             (- (if (< initial-modifier 1)
+                                  1
+                                  initial-modifier) 1)
                              (+ initial-modifier 1) step)
                             (mc/generate-configs base-config)))]
       (let [[config & rest-configs] configs


### PR DESCRIPTION
I realised when aiming to decrease a transition it could be possible for the modifier to become a negative value, which is non-ideal. This fix means that the lowest modifier possible is zero.