### PR TITLE
Allow modify transitions from or until a specific future year

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -2,7 +2,7 @@
 
 The config is an .edn file, essentially a map (`{}`) containing keys (`:foo`) and associated values. There are five sections to the config, defined as maps within the larger config map.
 
-As example config.edn can be found [here](https://github.com/MastodonC/witan.send/blob/master/data/demo/config.edn).
+As example config.edn can be found [here](../data/demo/config.edn).
 
 ### `:file-inputs`
 
@@ -16,9 +16,9 @@ The required keys are:
 - `:costs`
 - `:valid-states`
 
-The single optional key is `:settings-to-change` and is required when wanting to project a [“Modify setting(s) transitions rates”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario (more information in links).
+The single optional key is `:settings-to-change` and is required when wanting to project a [“Modify setting(s) transitions rates”](scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario (more information in links).
 
-Description of what each file should contain can be found [here](https://docs.google.com/document/d/138mSLMwTnH5ev1z0po07qGPxcfvuVkjR0ax8Yo88724/edit#) and example files can be found [here](https://github.com/MastodonC/witan.send/tree/master/data/demo/data).
+Description of what each file should contain can be found [here](https://docs.google.com/document/d/138mSLMwTnH5ev1z0po07qGPxcfvuVkjR0ax8Yo88724/edit#) and example files can be found [here](../data/demo/data).
 
 ### `:transition-parameters`
 
@@ -49,11 +49,11 @@ Operator keys include:
 
 Multiple entity pair filters can be applied in parallel.
 
-To be used for a [“Ignore historic data before a specific calendar year for an age group”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#ignore-historic-data-before-a-specific-calendar-year-for-an-age-group) scenario.
+To be used for a [“Ignore historic data before a specific calendar year for an age group”](scenarios.md#ignore-historic-data-before-a-specific-calendar-year-for-an-age-group) scenario.
 
 ##### `:modify-transitions-date-range`
 
-Expects a map with either `:from` or `:until` key and a calendar as an integer to modify transitions either from or until, when `:transitions-to-change` is used. Used for either a [“Modify setting(s) transitions rates”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
+Expects a map with either `:from` or `:until` key and a calendar as an integer to modify transitions either from or until, when `:transitions-to-change` is used. Used for either a [“Modify setting(s) transitions rates”](scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
 
 ##### `:transitions-to-change`
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -51,9 +51,9 @@ Multiple entity pair filters can be applied in parallel.
 
 To be used for a [“Ignore historic data before a specific calendar year for an age group”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#ignore-historic-data-before-a-specific-calendar-year-for-an-age-group) scenario.
 
-##### `:modify-transitions-from`
+##### `:modify-transitions-date-range`
 
-Expects a calendar year, provided as an integer, to start modifying transitions from, when `:modify-transition-by` & `:which-transitions?` are defined for either a [“Modify setting(s) transitions rates”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
+Expects a map with either `:from` or `:until` key and a calendar as an integer to modify transitions either from or until, when `:transitions-to-change` is used. Used for either a [“Modify setting(s) transitions rates”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](https://github.com/MastodonC/witan.send/blob/master/doc/scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
 
 ##### `:transitions-to-change`
 
@@ -67,7 +67,7 @@ Expects a vector of maps, with each map corresponding to a different type of tra
 * `:academic-year-2`
 * `:calendar-year`
 
-The more keys/entities used the more specific the set of transitions to be modified will be. The minimum number of entities is one, and no entity can be repeated (although you can specifiy a second map to define another set of transitions to modify). Each entity should have as a value either key (e.g. `:A`) corresponding to a need or setting, or an integer corresponding to an academic or calendar year. 
+The more keys/entities used the more specific the set of transitions to be modified will be. The minimum number of entities is one, and no entity can be repeated (although you can specifiy a second map to define another set of transitions to modify). Each entity should have as a value either key (e.g. `:A`) corresponding to a need or setting, or an integer corresponding to an academic or calendar year.
 
 A further additional, required key in each map is `:modify-transitions-by`, which should include a value corresponding to a number (integer or float) by which to multiply the count of transitions corresponding to the entity keys with which to filter on. For example a value of `2` here would double the number of transition of a specific type, and `0.5` would half them.
 

--- a/doc/scenarios.md
+++ b/doc/scenarios.md
@@ -2,7 +2,7 @@
 
 This is a short primer for how to use some of the parameters available in the witan.send model in order to run scenarios projections.
 
-Each of the paramater keys (e.g. `::settings-to-change`) can be found, and their values defined, in the [config.edn](https://github.com/MastodonC/witan.send/blob/master/data/demo/config.edn) file.
+Each of the paramater keys (e.g. `::settings-to-change`) can be found, and their values defined, in the [config.edn](../data/demo/config.edn) file.
 
 More information on how to define a scenario projection can be found [here](https://docs.google.com/document/d/1lQ2RrESpiyU5x2YUY8YvT287K4iq6NJw4jqHUIqC2VM/edit?ts=5b7d6444#heading=h.ebeiyry5kb3k).
 
@@ -28,7 +28,7 @@ Here each scenario projection is simply defined in terms of the collection of pa
   * `:academic-year-2`
   * `:calendar-year`
 * Defines single or multiple transition states to modify the rates of, and by how much
-* For [example](https://github.com/MastodonC/witan.send/blob/83cacebd36053a6e74f94ea36cdadac98cd8335a/data/demo/config-transitions-to-change.edn), a user may want to modify how many individuals are joining and moving to to the setting “A” in academic year 1 by increasing the current rate 40 fold.
+* For [example](../data/demo/config-transitions-to-change.edn), a user may want to modify how many individuals are joining and moving to to the setting “A” in academic year 1 by increasing the current rate 40 fold.
 
 ### _“Modify transitions from or until a specific future calendar year”_
 

--- a/doc/scenarios.md
+++ b/doc/scenarios.md
@@ -4,7 +4,7 @@ This is a short primer for how to use some of the parameters available in the wi
 
 Each of the paramater keys (e.g. `::settings-to-change`) can be found, and their values defined, in the [config.edn](https://github.com/MastodonC/witan.send/blob/master/data/demo/config.edn) file.
 
-More information on how to define a scenario projection can be found [here](https://docs.google.com/document/d/1lQ2RrESpiyU5x2YUY8YvT287K4iq6NJw4jqHUIqC2VM/edit?ts=5b7d6444#heading=h.ebeiyry5kb3k). 
+More information on how to define a scenario projection can be found [here](https://docs.google.com/document/d/1lQ2RrESpiyU5x2YUY8YvT287K4iq6NJw4jqHUIqC2VM/edit?ts=5b7d6444#heading=h.ebeiyry5kb3k).
 
 Here each scenario projection is simply defined in terms of the collection of parameters to use together, what arguments are expected and what the expected behaviuor is.
 
@@ -21,7 +21,7 @@ Here each scenario projection is simply defined in terms of the collection of pa
 * Parameters = `:transitions-to-change`
 * Arguments = a vector of map(s) each containing one or more entity keys (see below), each with corresponding keys or integers, and `:modify-transition-by` with a value corresponding to a number (integer or float) by which to multiply transitions matching the previous entity keys. Possible entity keys include:
   * `:setting-1`
-  * `:setting-2
+  * `:setting-2`
   * `:need-1`
   * `:need-2`
   * `:academic-year-1`
@@ -30,10 +30,10 @@ Here each scenario projection is simply defined in terms of the collection of pa
 * Defines single or multiple transition states to modify the rates of, and by how much
 * For [example](https://github.com/MastodonC/witan.send/blob/83cacebd36053a6e74f94ea36cdadac98cd8335a/data/demo/config-transitions-to-change.edn), a user may want to modify how many individuals are joining and moving to to the setting “A” in academic year 1 by increasing the current rate 40 fold.
 
-### _“Modify transitions from a specific future calendar year”_
+### _“Modify transitions from or until a specific future calendar year”_
 
-* Parameters = `:modify-transitions-from` and `:transitions-to-change
-* Arguments = as with above scenario, and additionally a calendar year (`2020`) from when a user may wish to apply the new transition rates
+* Parameters = `:modify-transitions-date-range` and `:transitions-to-change
+* Arguments = as with above scenario, and additionally a map with the key `:from` or `:until` and a calendar year (`2020`) from when a user may wish to apply the new transition rates, or until.
 * An [example](https://gist.github.com/seb231/0218cb773df526e4e99b992db028703d) may be that a user only wants to start modelling a transition rate policy change in three years time and maintain the current trends until that time
 
 ### _“Make a setting invalid”_

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -126,20 +126,27 @@
 
 (defn run-model-iteration
   "Takes the model & transitions, transition params, and the projected population and produce the next state of the model & transitions"
-  [modify-transitions-from
+  [modify-transitions-date-range
    make-setting-invalid
    standard-projection
    scenario-projection
    {population-by-state :model}
    [calendar-year projected-population]]
   (let [valid-transitions (:valid-transitions standard-projection)
-        params (if (nil? modify-transitions-from)
+        params (if (nil? modify-transitions-date-range)
                  (if ((complement nil?) scenario-projection)
                    scenario-projection
                    standard-projection)
-                 (if (>= calendar-year modify-transitions-from)
-                   scenario-projection
-                   standard-projection))
+                 (cond
+                   (contains? modify-transitions-date-range :from)
+                   (if (>= calendar-year (:from modify-transitions-date-range))
+                     scenario-projection
+                     standard-projection)
+
+                   (contains? modify-transitions-date-range :until)
+                   (if (<= calendar-year (:until modify-transitions-date-range))
+                     scenario-projection
+                     standard-projection)))
         cohorts (step/age-population projected-population population-by-state)
         [population-by-state transitions] (reduce (fn [pop cohort]
                                                     (apply-leavers-movers-for-cohort pop cohort params calendar-year valid-transitions make-setting-invalid))
@@ -160,11 +167,11 @@
        (filter (fn [[k _]] (> k seed-year)))
        (sort-by key)))
 
-(defn create-projections [simulations modify-transitions-from make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
+(defn create-projections [simulations modify-transitions-date-range make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
   (sequence
    (map (fn [simulation-run]
           (reductions (partial run-model-iteration
-                               modify-transitions-from
+                               modify-transitions-date-range
                                make-setting-invalid
                                inputs
                                modified-inputs)
@@ -176,7 +183,7 @@
   "Outputs the population for the last year of historic data, with one
    row for each individual/year/simulation. Also includes age & state columns"
   [{:keys [standard-projection scenario-projection modify-transition-by
-           modify-transitions-from seed-year make-setting-invalid]}
+           modify-transitions-date-range seed-year make-setting-invalid]}
    {:keys [random-seed simulations]}]
   (d/set-seed! random-seed)
   (println "Preparing" simulations "simulations...")
@@ -188,7 +195,7 @@
                                  (states/calculate-valid-year-settings-from-setting-academic-years valid-states)))
         inputs (assoc inputs :valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years valid-states))
         projection (create-projections simulations
-                                       modify-transitions-from
+                                       modify-transitions-date-range
                                        make-setting-invalid
                                        inputs
                                        modified-inputs

--- a/src/clj/witan/send/multi_config.clj
+++ b/src/clj/witan/send/multi_config.clj
@@ -11,7 +11,7 @@
                  :costs "data/costs.csv"
                  :valid-states "data/valid-states.csv"}
    :transition-parameters {:filter-transitions-from nil
-                           :modify-transitions-from nil
+                           :modify-transitions-date-range nil
                            :transitions-to-change nil
                            }
    :projection-parameters {:random-seed 50


### PR DESCRIPTION
Previously `modify-transitions-from` only allowed the ability to modify transitions at a specific future calendar year and onward. Now a user can set when they'd like to start or end modifying transitions in a projection (note: not both)