### PR TITLE
Use original transitions when calculating joiners per year

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -53,7 +53,7 @@ To be used for a [“Ignore historic data before a specific calendar year for an
 
 ##### `:modify-transitions-date-range`
 
-Expects a map with either `:from` or `:until` key and a calendar as an integer to modify transitions either from or until, when `:transitions-to-change` is used. Used for either a [“Modify setting(s) transitions rates”](scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
+Expects a map with either `:from` or `:until` key and a calendar year as an integer to modify transitions either from or until, when `:transitions-to-change` is used. Used for either a [“Modify setting(s) transitions rates”](scenarios.md#modify-settings-transitions-rates), [“Modify setting(s) transitions rates and transfer individuals to alternative setting(s)”](scenarios.md#modify-settings-transitions-rates-and-transfer-individuals-to-alternative-settings) or [“Modify transitions from a specific future calendar year”](scenarios.md#modify-transitions-from-a-specific-future-calendar-year) scenario.
 
 ##### `:transitions-to-change`
 

--- a/doc/dsdr/0002-modifying-joiner-rates.md
+++ b/doc/dsdr/0002-modifying-joiner-rates.md
@@ -1,0 +1,40 @@
+# Modify joiner rates (not number of joiners per year)
+
+## Context
+
+When calculating joiners rates the model counts the number of joiners
+for each academic year. It then works out the rate by which people 
+join each possible state for that academic year.
+
+This then means that, when increasing joiner transition rates to a
+specific state, not only does the likeliness of joining that state
+increase but also the rate by which that academic year's population
+increases. This then leads to a much larger population when the 
+scenario to be modelled is simply "increase joiner rate"
+
+## Decision
+
+When calculating the joiner rate, the original transitions data will 
+be used for either a standard or scenario projection. As previously for 
+scenario projections, when increasing the rate of a specific state
+modified transtion data will be used.
+
+## Status
+
+In review
+
+## Consequences
+
+### There is no way of increasing the overall SEND joiner rate
+
+This change makes it impossible to increase the overall number of 
+people joining SEND. This means it would not be possible to run 
+a scenario characterised as "we expect a larger population growth 
+in SEND in the future, than is currently projected" 
+
+### Some previous projections will not be repeatable with this change
+
+The behaviour above has been a desired effect of some previous 
+projections, and without returning to an older version of the model
+it would be impossible (without further development) to re-run these
+projections.

--- a/src/clj/witan/send/model/prepare.clj
+++ b/src/clj/witan/send/model/prepare.clj
@@ -85,7 +85,8 @@
    b))
 
 (defn prep-inputs [initial-send-pop validate-valid-states valid-transitions transitions
-                   transitions-filtered population valid-states original-transitions costs]
+                   transitions-filtered population valid-states original-transitions
+                   costs unmodified-transitions]
   (let [start-map {:population-by-state initial-send-pop
                    :valid-transitions valid-transitions
                    :valid-states valid-states
@@ -108,7 +109,7 @@
               :mover-state-alphas (p/alpha-params-movers validate-valid-states valid-transitions transitions-filtered)})
       (merge start-map
              {:joiner-beta-params (p/beta-params-joiners validate-valid-states
-                                                         transitions
+                                                         unmodified-transitions
                                                          population)
               :leaver-beta-params (p/beta-params-leavers validate-valid-states transitions)
               :joiner-state-alphas (p/alpha-params-joiners validate-valid-states (transitions-map transitions))
@@ -280,12 +281,12 @@
     {:standard-projection (prep-inputs initial-send-pop validate-valid-states
                                        valid-transitions transitions
                                        transitions-filtered population valid-states
-                                       original-transitions costs)
+                                       original-transitions costs transitions)
      :scenario-projection (when modified-transitions
                             (prep-inputs initial-send-pop validate-valid-states
                                          valid-transitions modified-transitions
                                          transitions-filtered population valid-states
-                                         original-transitions costs))
+                                         original-transitions costs transitions))
      :seed-year (inc max-transition-year)
      :make-setting-invalid make-setting-invalid
      :modify-transitions-date-range modify-transitions-date-range}))


### PR DESCRIPTION
See [DSDR](doc/0002-modifying-joiner-rates.md) for reasoning for this change

With this change I would also like to close and delete the following branches as they are now outdated by this or other work:
- [double_joiner_a](https://github.com/MastodonC/witan.send/tree/double_joiner_a)
- [remove-scenario-implementation](https://github.com/MastodonC/witan.send/tree/remove-scenario-implementation)
- [scenario-alt-2](https://github.com/MastodonC/witan.send/tree/scenario-alt-2)