### PR TITLE
Log the config on an exception in run-recorded-send

### DIFF
--- a/src/clj/witan/send/main.clj
+++ b/src/clj/witan/send/main.clj
@@ -59,14 +59,17 @@
    (vm/run-send-validation config)))
 
 (defn run-recorded-send [config]
-  (let [metadata (md/metadata config)]
-    (so/output-send-results
-      (send/run-send-workflow config)
-      (:output-parameters config))
-    (when (get-in config [:validation-parameters :run-validation])
-      (vm/run-send-validation config))
-    (save-runtime-config config)
-    (save-runtime-metadata config metadata)))
+  (try
+    (let [metadata (md/metadata config)]
+      (so/output-send-results
+       (send/run-send-workflow config)
+       (:output-parameters config))
+      (when (get-in config [:validation-parameters :run-validation])
+        (vm/run-send-validation config))
+      (save-runtime-config config)
+      (save-runtime-metadata config metadata))
+    (catch Exception e
+      (throw (ex-info "Couldn't run recorded send." {:config config} e)))))
 
 (defn -main
   "Run the send model producing outputs, defaulting to the inbuilt demo


### PR DESCRIPTION
So we can make sure any config transformations are successful.