### PR TITLE
Deconstructed send

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ data/demo/validation/
 .Rproj.user
 *.Rproj
 *.ipynb_checkpoints
+gc.log*
+.clj-kondo/
+.lsp/
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths ["src/clj"]
- :deps  {org.clojure/clojure              {:mvn/version "1.9.0" #_"1.10.1"}
-         ;; moving to 1.10.1 inexplicably causes tests to fail
-         org.clojure/core.async           {:mvn/version "1.3.610"}
+ :deps  {org.clojure/clojure              {:mvn/version #_"1.9.0" "1.10.1"}
+         org.clojure/core.async           {:mvn/version "1.5.648"}
          org.clojure/data.csv             {:mvn/version "0.1.4"}
          org.clojure/math.combinatorics   {:mvn/version "0.1.4"}
          aero/aero                        {:mvn/version "1.1.3"}
@@ -9,15 +8,28 @@
          com.cognitect/transit-clj        {:mvn/version "1.0.324"}
          digest/digest                    {:mvn/version "1.4.8"}
          instaparse/instaparse            {:mvn/version "1.4.9"}
-         kixi/stats                       {:mvn/version "0.4.3" #_"0.5.4"}
+         kixi/stats                       {:mvn/version "0.4.3" #_ "0.5.4"}
          me.raynes/fs                     {:mvn/version "1.4.6"}
          medley/medley                    {:mvn/version "1.0.0"}
          org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
          ;; upgrading to 2.1.10 causes a test to fail
-         org.hdrhistogram/HdrHistogram    {:mvn/version "2.1.9" #_"2.1.12"}
-         same/ish                         {:mvn/version "0.1.4"}}
+         org.hdrhistogram/HdrHistogram    {:mvn/version "2.1.9" #_ "2.1.12"}
+         same/ish                         {:mvn/version "0.1.4"}
+         techascent/tech.ml.dataset       {:mvn/version "6.059" #_"6.052"}
+         scicloj/tablecloth               {:mvn/version "6.051"
+                                           :exclusions  [techascent/tech.ml.dataset
+                                                         org.apache.poi/poi-ooxml-schemas
+                                                         org.apache.poi/poi
+                                                         org.apache.poi/poi-ooxml]}}
  :aliases
- {:big-mem {:jvm-opts ["-Xmx8g"]}
+ {:jdk-17
+  {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"
+              "-Xlog:gc*:gc.log"
+              "-XX:+UseZGC"
+              "-Xmx32g"
+              "--add-modules" "jdk.incubator.foreign,jdk.incubator.vector"
+              "--enable-native-access=ALL-UNNAMED"]}
+  :big-mem {:jvm-opts ["-Xmx8g"]}
   :test    {:jvm-opts    ["-Xmx8g"]
             :extra-paths ["test"]
             :extra-deps  {org.clojure/test.check {:mvn/version "0.9.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -15,12 +15,24 @@
          ;; upgrading to 2.1.10 causes a test to fail
          org.hdrhistogram/HdrHistogram    {:mvn/version "2.1.9" #_ "2.1.12"}
          same/ish                         {:mvn/version "0.1.4"}
-         techascent/tech.ml.dataset       {:mvn/version "6.059" #_"6.052"}
-         scicloj/tablecloth               {:mvn/version "6.051"
+
+         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+         ;; All of this should probably go in adroddiad or similar
+         techascent/tech.ml.dataset       {:mvn/version "6.077"} ;; has claypoole in dtype.next
+         scicloj/tablecloth               {:mvn/version "6.076"
                                            :exclusions  [techascent/tech.ml.dataset
                                                          org.apache.poi/poi-ooxml-schemas
                                                          org.apache.poi/poi
-                                                         org.apache.poi/poi-ooxml]}}
+                                                         org.apache.poi/poi-ooxml]}
+         org.apache.parquet/parquet-hadoop              {:mvn/version "1.12.0"
+                                                         :exclusions  [org.slf4j/slf4j-log4j12]}
+         org.apache.hadoop/hadoop-common                {:mvn/version "3.3.0"
+                                                         :exclusions  [org.slf4j/slf4j-log4j12]}
+         ;; We literally need this for 1 POJO formatting object.
+         org.apache.hadoop/hadoop-mapreduce-client-core {:mvn/version "3.3.0"
+                                                         :exclusions  [org.slf4j/slf4j-log4j12]}
+
+         }
  :aliases
  {:jdk-17
   {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"

--- a/src/clj/witan/send.clj
+++ b/src/clj/witan/send.clj
@@ -108,8 +108,10 @@
                                    [need-2 setting-2] (-> key
                                                           (nth 3)
                                                           (states/split-need-setting))]
-                               {:calendar-year (nth key 0)
-                                :academic-year (nth key 1)
+                               {:calendar-year (dec (nth key 0))
+                                :calendar-year-2 (nth key 0)
+                                :academic-year-1 (dec (nth key 1))
+                                :academic-year-2 (nth key 1)
                                 :need-1 need-1
                                 :setting-1 setting-1
                                 :need-2 need-2
@@ -119,8 +121,10 @@
                            transitions))
                     $)
             (tc/dataset $)
-            (tc/convert-types $ {:academic-year :int16
+            (tc/convert-types $ {:academic-year-1 :int16
+                                 :academic-year-2 :int16
                                  :calendar-year :int16
+                                 :calendar-year-2 :int16
                                  :simulation :int16
                                  :transition-count :int32}))))))
 
@@ -182,11 +186,13 @@
 
   (-> foo
       first
-      (tc/info));; => _unnamed: descriptive-stats [8 12]:
+      (tc/info));; => _unnamed: descriptive-stats [10 12]:
   ;;    |         :col-name | :datatype | :n-valid | :n-missing |   :min |         :mean |    :mode |   :max | :standard-deviation |       :skew |   :first |    :last |
   ;;    |-------------------|-----------|---------:|-----------:|-------:|--------------:|----------|-------:|--------------------:|------------:|----------|----------|
-  ;;    |    :academic-year |    :int16 |     4637 |          0 |   -2.0 |    8.34699159 |          |   20.0 |          4.90374763 | -0.12309428 |       15 |        3 |
-  ;;    |    :calendar-year |    :int16 |     4637 |          0 | 2018.0 | 2020.04356265 |          | 2022.0 |          1.41598178 | -0.03550839 |     2018 |     2022 |
+  ;;    |  :academic-year-1 |    :int16 |     4637 |          0 |   -3.0 |    7.34699159 |          |   19.0 |          4.90374763 | -0.12309428 |       14 |        2 |
+  ;;    |  :academic-year-2 |    :int16 |     4637 |          0 |   -2.0 |    8.34699159 |          |   20.0 |          4.90374763 | -0.12309428 |       15 |        3 |
+  ;;    |    :calendar-year |    :int16 |     4637 |          0 | 2017.0 | 2019.04356265 |          | 2021.0 |          1.41598178 | -0.03550839 |     2017 |     2021 |
+  ;;    |  :calendar-year-2 |    :int16 |     4637 |          0 | 2018.0 | 2020.04356265 |          | 2022.0 |          1.41598178 | -0.03550839 |     2018 |     2022 |
   ;;    |           :need-1 |  :keyword |     4637 |          0 |        |               |       :T |        |                     |             |       :T |       :U |
   ;;    |           :need-2 |  :keyword |     4637 |          0 |        |               | :NONSEND |        |                     |             | :NONSEND | :NONSEND |
   ;;    |        :setting-1 |  :keyword |     4637 |          0 |        |               |       :B |        |                     |             |       :N |       :J |

--- a/src/clj/witan/send.clj
+++ b/src/clj/witan/send.clj
@@ -1,0 +1,193 @@
+(ns witan.send
+  (:require [aero.core :as aero]
+            [clojure.java.io :as io]
+            [clojure.core.async :as async]
+            [tablecloth.api :as tc]
+            [witan.send.distributions :as d]
+            [witan.send.model.prepare :as p]
+            [witan.send.model.input.population :as wip]
+            [witan.send.model.input.settings-to-change :as wistc]
+            [witan.send.model.input.transitions :as wit]
+            [witan.send.model.input.valid-states :as wivs]
+            [witan.send.model.run :as r]
+            [witan.send.states :as states]))
+
+;; FIXME: this should go in its own config namespace
+(defn read-config
+  "Read a config file and merge it with schema inputs"
+  [config-path]
+  (let [project-dir (or (.getParent (io/as-file config-path))
+                        (System/getProperty "user.dir"))]
+    (merge-with merge
+                (aero/read-config config-path)
+                ;; default-schemas
+                {:project-dir project-dir}
+                {:output-parameters {:project-dir project-dir}})))
+
+(defn build-input-datasets
+  "Build a map of the datasets to use for input"
+  [project-dir {:keys [_costs population settings-to-change transitions valid-states]}]
+  (let [input-datasets {;; :costs (wic/csv->costs (str project-dir "/" costs))
+                        :population (wip/csv->population (str project-dir "/" population))
+                        :transitions (wit/csv->transitions (str project-dir "/" transitions))
+                        :valid-states (wivs/csv->valid-states (str project-dir "/" valid-states))}]
+    (if settings-to-change
+      (assoc input-datasets :settings-to-change (wistc/csv->settings-to-change (str project-dir "/" settings-to-change))) ;; do we need this?
+      input-datasets)))
+
+(defn train-model [{:keys [input-datasets config print-warnings?]
+                    :as state}]
+  (p/prepare-send-inputs input-datasets (:transition-parameters config) print-warnings?))
+
+#_(defn run-model [{:keys [model config]
+                    :as state}]
+    (r/run-send-model model (:projection-parameters config)))
+
+(defn create-projections [simulations modify-transitions-date-range make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
+  (map (fn [simulation-run]
+         [simulation-run (reductions (partial r/run-model-iteration
+                                              modify-transitions-date-range
+                                              make-setting-invalid
+                                              inputs
+                                              modified-inputs)
+                                     {:model population-by-state}
+                                     (r/projected-future-pop-by-year projected-population seed-year))])
+       (range simulations)))
+
+(def ->dataset-seq-xf
+  (comp
+   (map (fn [[simulation-idx simulation-data]]
+          (map (fn [sd]
+                 (assoc sd :simulation simulation-idx))
+               simulation-data)))
+   (map (fn [simulation]
+          (->> simulation
+               (filter :transitions)
+               (mapcat (fn [{:keys [transitions simulation]}]
+                         (map (fn [map-entry]
+                                (let [key (first map-entry)
+                                      transition-count (second map-entry)
+                                      [need-1 setting-1] (-> key
+                                                             (nth 2)
+                                                             (states/split-need-setting))
+                                      [need-2 setting-2] (-> key
+                                                             (nth 3)
+                                                             (states/split-need-setting))]
+                                  {:calendar-year (nth key 0)
+                                   :academic-year (nth key 1)
+                                   :need-1 need-1
+                                   :setting-1 setting-1
+                                   :need-2 need-2
+                                   :setting-2 setting-2
+                                   :transition-count transition-count
+                                   :simulation simulation}))
+                              transitions)))
+               (tc/dataset))))))
+
+(defn ->dataset-seq [simulations]
+  (sequence
+   ->dataset-seq-xf
+   simulations))
+
+
+(defn run-model
+  "Outputs the population for the last year of historic data, with one
+   row for each individual/year/simulation. Also includes age & state columns"
+  [{:keys [standard-projection scenario-projection modify-transition-by
+           modify-transitions-date-range seed-year make-setting-invalid]
+    :as _trained-model}
+   {:keys [random-seed simulations]
+    :as _projection-parameters}]
+  (d/set-seed! random-seed)
+  (println "Preparing" simulations "simulations...")
+  (let [{:keys [population population-by-state
+                projected-population cost-lookup
+                valid-states transitions] :as inputs} standard-projection
+        modified-inputs (when ((complement nil?) scenario-projection)
+                          (assoc scenario-projection :valid-year-settings
+                                 (states/calculate-valid-year-settings-from-setting-academic-years valid-states)))
+        inputs (assoc inputs :valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years valid-states))
+        projection (create-projections simulations
+                                       modify-transitions-date-range
+                                       make-setting-invalid
+                                       inputs
+                                       modified-inputs
+                                       population-by-state
+                                       projected-population
+                                       seed-year)]
+    (->dataset-seq projection)))
+
+
+(comment
+
+  ;; EXAMPLE: This is what a baseline run would look like
+  (let [config (read-config "data/demo/config.edn")
+        input-datasets (build-input-datasets (:project-dir config) (:file-inputs config))
+        model (train-model {:input-datasets input-datasets
+                            :config config
+                            :print-warnings? true})
+        model-results (run-model model (:projection-parameters config))]
+    ;; mush the seq of datasets together (tho probably better to run
+    ;; it through a ds/reducer of some sort
+    (apply tc/concat-copying model-results))
+
+  ;; Or do each step so you can tweak the results of one
+  (def config (read-config "data/demo/config.edn"))
+  (def input-datasets (build-input-datasets (:project-dir config) (:file-inputs config)))
+  (def model (train-model {:input-datasets input-datasets
+                           :config config
+                           :print-warnings? true}))
+  (def model-results (run-model model (:projection-parameters config)))
+  (->dataset-seq model-results)
+
+  )
+
+
+(comment
+
+  ;; FIXME: I don't like these versions as much
+
+  ;; FIXME: I prefer ->dataset-seq-xf
+  (def ->dataset-xf
+    (comp
+     (mapcat (fn [[simulation-idx simulation-data]]
+               (map (fn [sd]
+                      (assoc sd :simulation simulation-idx))
+                    simulation-data)))
+     (filter :transitions)
+     (mapcat (fn [{:keys [transitions simulation]}]
+               (map (fn [map-entry]
+                      (let [key (first map-entry)
+                            transition-count (second map-entry)
+                            [need-1 setting-1] (-> key
+                                                   (nth 2)
+                                                   (states/split-need-setting))
+                            [need-2 setting-2] (-> key
+                                                   (nth 3)
+                                                   (states/split-need-setting))]
+                        {:calendar-year (nth key 0)
+                         :academic-year (nth key 1)
+                         :need-1 need-1
+                         :setting-1 setting-1
+                         :need-2 need-2
+                         :setting-2 setting-2
+                         :transition-count transition-count
+                         :simulation simulation}))
+                    transitions)))))
+
+  ;; FIXME: I prefer ->dataset-seq
+  (defn ->dataset [simulations]
+    (-> (let [to (async/chan 1024)]
+          (async/pipeline
+           (* 3 (quot (.availableProcessors (Runtime/getRuntime)) 4))
+           to
+           ->dataset-xf
+           (async/to-chan!! simulations))
+          (async/<!! (async/into [] to)))
+        (tc/dataset)
+        (tc/convert-types {:academic-year :int16
+                           :calendar-year :int16
+                           :simulation :int16
+                           :transition-count :int32})))
+
+  )

--- a/src/clj/witan/send.clj
+++ b/src/clj/witan/send.clj
@@ -1,9 +1,7 @@
 (ns witan.send
   (:require [aero.core :as aero]
             [clojure.java.io :as io]
-            [clojure.core.async :as async]
             [medley.core :as medley]
-            [tablecloth.api :as tc]
             [witan.send.distributions :as d]
             [witan.send.maths :as m]
             [witan.send.model.prepare :as p]
@@ -15,7 +13,7 @@
             [witan.send.params :as params]
             [witan.send.states :as states]))
 
-;; FIXME: this should go in its own config namespace
+;; FIXME: this should go into witan.send.config
 (defn read-config
   "Read a config file and merge it with schema inputs"
   [config-path]
@@ -27,10 +25,11 @@
                 {:project-dir project-dir}
                 {:output-parameters {:project-dir project-dir}})))
 
+;; FIXME: this should go into witan.send.input
 (defn build-input-datasets
   "Build a map of the datasets to use for input"
   [project-dir {:keys [_costs population settings-to-change transitions valid-states]}]
-  (let [input-datasets {;; :costs (wic/csv->costs (str project-dir "/" costs))
+  (let [input-datasets { ;; :costs (wic/csv->costs (str project-dir "/" costs))
                         :population (wip/csv->population (str project-dir "/" population))
                         :transitions (wit/csv->transitions (str project-dir "/" transitions))
                         :valid-states (wivs/csv->valid-states (str project-dir "/" valid-states))}]
@@ -54,7 +53,7 @@
           {}
           dataset))
 
-
+;; FIXME: this should go into witan.send.train
 (defn train-model
   "train-model returns a map that can populate `:standard-projection`
   or `:scenario-projection` when running the model.
@@ -106,119 +105,7 @@
 (defn seed-year [transitions]
   (inc (reduce max (map :calendar-year transitions))))
 
-#_(defn run-model [{:keys [model config]
-                    :as state}]
-    (r/run-send-model model (:projection-parameters config)))
-
-;; Deprecated
-;; (defn create-projections [simulations modify-transitions-date-range make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
-;;   (map (fn [simulation-run]
-;;          [simulation-run (reductions (partial r/run-model-iteration
-;;                                               modify-transitions-date-range
-;;                                               make-setting-invalid
-;;                                               inputs
-;;                                               modified-inputs)
-;;                                      {:model population-by-state}
-;;                                      (r/projected-future-pop-by-year projected-population seed-year))])
-;;        (range simulations)))
-
-(defn create-projections-xf [modify-transitions-date-range make-setting-invalid inputs modified-inputs population-by-state projected-population seed-year]
-  (map (fn [simulation-run]
-         [simulation-run (reductions (partial r/run-model-iteration
-                                              modify-transitions-date-range
-                                              make-setting-invalid
-                                              inputs
-                                              modified-inputs)
-                                     {:model population-by-state}
-                                     (r/projected-future-pop-by-year projected-population seed-year))])))
-
-
-(defn unpack-transition-counts [{:keys [transitions simulation]}]
-  (map (fn [map-entry]
-         (let [key (first map-entry)
-               transition-count (second map-entry)
-               [need-1 setting-1] (-> key
-                                      (nth 2)
-                                      (states/split-need-setting))
-               [need-2 setting-2] (-> key
-                                      (nth 3)
-                                      (states/split-need-setting))]
-           {:calendar-year (dec (nth key 0))
-            :calendar-year-2 (nth key 0)
-            :academic-year-1 (dec (nth key 1))
-            :academic-year-2 (nth key 1)
-            :need-1 need-1
-            :setting-1 setting-1
-            :need-2 need-2
-            :setting-2 setting-2
-            :transition-count transition-count
-            :simulation simulation}))
-       transitions))
-
-(defn add-simulation-idx [simulation-idx sd]
-  (assoc sd :simulation simulation-idx))
-
-(def ->dataset-seq-xf
-  (comp
-   (map (fn [[simulation-idx simulation-data]]
-          (map (partial add-simulation-idx simulation-idx) simulation-data)))
-   (map (fn [simulation]
-          (as-> simulation $
-            (filter :transitions $)
-            (mapcat unpack-transition-counts $)
-            (tc/dataset $)
-            (tc/map-columns $ :need-1 [:need-1] name)
-            (tc/map-columns $ :need-2 [:need-2] name)
-            (tc/map-columns $ :setting-1 [:setting-1] name)
-            (tc/map-columns $ :setting-2 [:setting-2] name)
-            (tc/convert-types $ {:academic-year-1  :int16
-                                 :academic-year-2  :int16
-                                 :calendar-year    :int16
-                                 :calendar-year-2  :int16
-                                 :simulation       :int16
-                                 :transition-count :int32}))))))
-
-(defn ->dataset-seq [simulations]
-  (sequence
-   ->dataset-seq-xf
-   simulations))
-
-;; Deprecated
-;; (defn run-model
-;;   "Outputs a seq of datasets. One for each simulation.
-
-;;   Each simulation is made up of
-;;   :simulation
-;;   :calendar-year
-;;   :academic-year
-;;   :need-1 :setting-1
-;;   :need-2 :setting-2
-;;   :transition-count"
-;;   [{:keys [standard-projection scenario-projection modify-transition-by
-;;            modify-transitions-date-range seed-year make-setting-invalid]
-;;     :as _trained-model}
-;;    {:keys [random-seed simulations]
-;;     :as _projection-parameters}]
-;;   (d/set-seed! random-seed)
-;;   (println "Preparing" simulations "simulations...")
-;;   (let [{:keys [population population-by-state
-;;                 projected-population cost-lookup
-;;                 valid-states transitions] :as inputs} standard-projection
-;;         modified-inputs (when ((complement nil?) scenario-projection)
-;;                           (assoc scenario-projection :valid-year-settings
-;;                                  (states/calculate-valid-year-settings-from-setting-academic-years valid-states)))
-;;         inputs (assoc inputs :valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years valid-states))
-;;         projection (create-projections simulations
-;;                                        modify-transitions-date-range
-;;                                        make-setting-invalid
-;;                                        inputs
-;;                                        modified-inputs
-;;                                        population-by-state
-;;                                        projected-population
-;;                                        seed-year)]
-;;     (->dataset-seq projection)))
-
-(defn run-model-xf
+(defn create-projections-xf
   "Outputs a seq of datasets. One for each simulation.
 
   Each simulation is made up of
@@ -241,104 +128,11 @@
                                (assoc scenario-projection :valid-year-settings
                                       (states/calculate-valid-year-settings-from-setting-academic-years valid-states)))
         standard-projection' (assoc standard-projection :valid-year-settings (states/calculate-valid-year-settings-from-setting-academic-years valid-states))]
-    (create-projections-xf
-     modify-transitions-date-range
-     make-setting-invalid
-     standard-projection'
-     scenario-projection'
-     population-by-state
-     projected-population
-     seed-year)))
-
-
-(comment
-
-  ;; EXAMPLE: This is what a baseline run would look like
-  (def foo
-    (let [config (read-config "data/demo/config.edn")
-          input-datasets (build-input-datasets (:project-dir config) (:file-inputs config))
-          model (train-model {:input-datasets input-datasets
-                              :config config
-                              :print-warnings? true})
-          model-results (run-model model (:projection-parameters config))]
-      ;; mush the seq of datasets together (tho probably better to run
-      ;; it through a ds/reducer of some sort
-      ;; (apply tc/concat-copying model-results)
-      model-results))
-
-  (-> foo
-      first
-      (tc/info));; => _unnamed: descriptive-stats [10 12]:
-  ;;    |         :col-name | :datatype | :n-valid | :n-missing |   :min |         :mean |    :mode |   :max | :standard-deviation |       :skew |   :first |    :last |
-  ;;    |-------------------|-----------|---------:|-----------:|-------:|--------------:|----------|-------:|--------------------:|------------:|----------|----------|
-  ;;    |  :academic-year-1 |    :int16 |     4637 |          0 |   -3.0 |    7.34699159 |          |   19.0 |          4.90374763 | -0.12309428 |       14 |        2 |
-  ;;    |  :academic-year-2 |    :int16 |     4637 |          0 |   -2.0 |    8.34699159 |          |   20.0 |          4.90374763 | -0.12309428 |       15 |        3 |
-  ;;    |    :calendar-year |    :int16 |     4637 |          0 | 2017.0 | 2019.04356265 |          | 2021.0 |          1.41598178 | -0.03550839 |     2017 |     2021 |
-  ;;    |  :calendar-year-2 |    :int16 |     4637 |          0 | 2018.0 | 2020.04356265 |          | 2022.0 |          1.41598178 | -0.03550839 |     2018 |     2022 |
-  ;;    |           :need-1 |  :keyword |     4637 |          0 |        |               |       :T |        |                     |             |       :T |       :U |
-  ;;    |           :need-2 |  :keyword |     4637 |          0 |        |               | :NONSEND |        |                     |             | :NONSEND | :NONSEND |
-  ;;    |        :setting-1 |  :keyword |     4637 |          0 |        |               |       :B |        |                     |             |       :N |       :J |
-  ;;    |        :setting-2 |  :keyword |     4637 |          0 |        |               | :NONSEND |        |                     |             | :NONSEND | :NONSEND |
-  ;;    |       :simulation |    :int16 |     4637 |          0 |    0.0 |    0.00000000 |          |    0.0 |          0.00000000 |         NaN |        0 |        0 |
-  ;;    | :transition-count |    :int32 |     4637 |          0 |    0.0 |    2.77377615 |          |   79.0 |          7.21378957 |  6.33194149 |        0 |        0 |
-
-  ;; Or do each step so you can tweak the results of one
-  (def config (read-config "data/demo/config.edn"))
-  (def input-datasets (build-input-datasets (:project-dir config) (:file-inputs config)))
-  (def model (train-model {:input-datasets input-datasets
-                           :config config
-                           :print-warnings? true}))
-  (def model-results (run-model model (:projection-parameters config)))
-  (->dataset-seq model-results)
-
-  )
-
-
-(comment
-
-  ;; FIXME: I don't like these versions as much
-
-  ;; FIXME: I prefer ->dataset-seq-xf
-  (def ->dataset-xf
-    (comp
-     (mapcat (fn [[simulation-idx simulation-data]]
-               (map (fn [sd]
-                      (assoc sd :simulation simulation-idx))
-                    simulation-data)))
-     (filter :transitions)
-     (mapcat (fn [{:keys [transitions simulation]}]
-               (map (fn [map-entry]
-                      (let [key (first map-entry)
-                            transition-count (second map-entry)
-                            [need-1 setting-1] (-> key
-                                                   (nth 2)
-                                                   (states/split-need-setting))
-                            [need-2 setting-2] (-> key
-                                                   (nth 3)
-                                                   (states/split-need-setting))]
-                        {:calendar-year (nth key 0)
-                         :academic-year (nth key 1)
-                         :need-1 need-1
-                         :setting-1 setting-1
-                         :need-2 need-2
-                         :setting-2 setting-2
-                         :transition-count transition-count
-                         :simulation simulation}))
-                    transitions)))))
-
-  ;; FIXME: I prefer ->dataset-seq
-  (defn ->dataset [simulations]
-    (-> (let [to (async/chan 1024)]
-          (async/pipeline
-           (* 3 (quot (.availableProcessors (Runtime/getRuntime)) 4))
-           to
-           ->dataset-xf
-           (async/to-chan!! simulations))
-          (async/<!! (async/into [] to)))
-        (tc/dataset)
-        (tc/convert-types {:academic-year :int16
-                           :calendar-year :int16
-                           :simulation :int16
-                           :transition-count :int32})))
-
-  )
+    (map (fn [simulation-run]
+           [simulation-run (reductions (partial r/run-model-iteration
+                                                modify-transitions-date-range
+                                                make-setting-invalid
+                                                standard-projection'
+                                                scenario-projection')
+                                       {:model population-by-state}
+                                       (r/projected-future-pop-by-year projected-population seed-year))]))))

--- a/src/clj/witan/send.clj
+++ b/src/clj/witan/send.clj
@@ -35,8 +35,43 @@
       (assoc input-datasets :settings-to-change (wistc/csv->settings-to-change (str project-dir "/" settings-to-change))) ;; do we need this?
       input-datasets)))
 
-(defn train-model [{:keys [input-datasets config print-warnings?]
-                    :as state}]
+(defn train-model
+  "train-model returns a map of:
+    - :standard-projection
+    - :scenario-projection
+    - :seed-year
+    - :make-setting-invalid
+    - :modify-transitions-date-range
+
+  Under the :standard-projection and :scenario-projection key is a map with the following keys:
+   Starting data for the projection
+   - :population-by-state which is a map of [ academic-year need-setting ] population-count of the SEND population
+   - :transitions a seq of maps containing
+     - :calendar-year the January census point year for the *-1 side
+     - :academic-year-1 :setting-1 :need-1
+     - :academic-year-2 :setting-2 :need-2
+   - :population a seq of
+    - :calendar-year
+    - :academic-year
+    - :population - representing the background population for that NCY not the SEND population
+   - :projected-population a map of calendar-year to maps of academic-year to background population.
+     A simple transformation of :population
+
+  Distributions for the projection
+   - :joiner-beta-params The odds (alpha beta) of joining SEND my NCY
+   - :joiner-state-alphas A map of academic-year to a map of need-setting odds of arriving in that need-setting
+   - :mover-beta-params - The odds of a NCY/need/setting moving to another SEND setting
+   - :mover-state-alphas - a map of [ NCY need-setting ] to a map of {need-setting odds of being in that need-setting}
+   - :leaver-beta-params - The odds of [ NCY need-setting ] leaving SEND
+
+  Cost Data
+   - :cost-lookup - currently not used, but is a mapping on need/setting to cost
+
+  Valid transition movement data
+   - :valid-transitions
+   - valid-states"
+  [{:keys [input-datasets config print-warnings?]
+    :as state}]
   (p/prepare-send-inputs input-datasets (:transition-parameters config) print-warnings?))
 
 #_(defn run-model [{:keys [model config]

--- a/src/clj/witan/send/model/run.clj
+++ b/src/clj/witan/send/model/run.clj
@@ -165,7 +165,7 @@
   (let [valid-transitions (:valid-transitions standard-projection)
         params (modify-transitions-params modify-transitions-date-range scenario-projection
                                           standard-projection calendar-year)
-        cohorts (step/age-population projected-population population-by-state)
+        cohorts (step/age-population population-by-state)
         [population-by-state transitions] (reduce (fn [pop cohort]
                                                     (apply-leavers-movers-for-cohort pop cohort params calendar-year valid-transitions make-setting-invalid))
                                                   [{} {}]

--- a/src/clj/witan/send/parquet.clj
+++ b/src/clj/witan/send/parquet.clj
@@ -1,0 +1,101 @@
+(ns witan.send.parquet
+  (:require [com.climate.claypoole :as cp]
+            [com.climate.claypoole.lazy :as lazy]
+            [tablecloth.api :as tc]
+            [tech.v3.libs.parquet :as parquet]
+            [witan.send :as send]
+            [witan.send.states :as states]))
+
+(defn unpack-transition-counts [{:keys [transitions simulation]}]
+  (map (fn [map-entry]
+         (let [key (first map-entry)
+               transition-count (second map-entry)
+               [need-1 setting-1] (-> key
+                                      (nth 2)
+                                      (states/split-need-setting))
+               [need-2 setting-2] (-> key
+                                      (nth 3)
+                                      (states/split-need-setting))]
+           {:calendar-year (dec (nth key 0))
+            :calendar-year-2 (nth key 0)
+            :academic-year-1 (dec (nth key 1))
+            :academic-year-2 (nth key 1)
+            :need-1 need-1
+            :setting-1 setting-1
+            :need-2 need-2
+            :setting-2 setting-2
+            :transition-count transition-count
+            :simulation simulation}))
+       transitions))
+
+(defn add-simulation-idx [simulation-idx sd]
+  (assoc sd :simulation simulation-idx))
+
+(def ->dataset-seq-xf
+  (comp
+   (map (fn [[simulation-idx simulation-data]]
+          (map (partial add-simulation-idx simulation-idx) simulation-data)))
+   (map (fn [simulation]
+          (as-> simulation $
+            (filter :transitions $)
+            (mapcat unpack-transition-counts $)
+            (tc/dataset $)
+            (tc/map-columns $ :need-1 [:need-1] name)
+            (tc/map-columns $ :need-2 [:need-2] name)
+            (tc/map-columns $ :setting-1 [:setting-1] name)
+            (tc/map-columns $ :setting-2 [:setting-2] name)
+            (tc/convert-types $ {:academic-year-1  :int16
+                                 :academic-year-2  :int16
+                                 :calendar-year    :int16
+                                 :calendar-year-2  :int16
+                                 :simulation       :int16
+                                 :transition-count :int32}))))))
+
+(defn output-ds-seq
+  [out-dir prefix ds-seq]
+  (let [start          (System/currentTimeMillis)
+        idx            (-> ds-seq first :simulation first)
+        num-ds         (count ds-seq)
+        _              (println (format "Processing Simulation %d" idx))
+        base-file-name (format "%s-%05d.parquet" prefix idx)
+        _              (println (format "File: %s" base-file-name))
+        file-name      (str out-dir base-file-name)]
+    {:file-name          file-name
+     :number-of-datasets num-ds
+     :status             (parquet/ds-seq->parquet file-name ds-seq)
+     :elapsed-time       (- (System/currentTimeMillis) start)}))
+
+
+(defn create-projections-and-save [{:keys [prefix out-dir config] :as projection-config}
+                                   sim-range]
+  (->> (into []
+             (comp
+              (send/create-projections-xf projection-config
+                                          (:projection-parameters config))
+              ->dataset-seq-xf)
+             sim-range)
+       (output-ds-seq out-dir prefix)))
+
+(defn parallel-create-projections-and-save
+  "Takes a map of
+   - :config the read in config file (required)
+   - :out-dir as a location for the parquet files to be written to (required)
+   - :prefix as a prefix for the parquet files (require)
+   - :standard-projection as the baseline model (required)
+   - :seed-year 1 greater than the max year of the input transitions as the jumping off point (required)
+   - :scenario-projection as the scenario model (optional)
+   - :modify-transitions-data-range years to apply the scenario-projection (optional)
+
+  It then runs the projection in groups of 50 simulations that get
+  written to the same parquet file, so 1000 simulations would create
+  20 parquet files.
+
+  The projection is run in the order that things are completed to best
+  saturate the cores of whatever machine is running the simulation.
+  "
+  [{:keys [config] :as projection-config}]
+  (cp/with-shutdown! [cpu-pool (cp/threadpool (- (cp/ncpus) 2))]
+    (->> (range (get-in config [:projection-parameters :simulations] 1)) ;; Just 1 simulation if nothing is specified
+         (partition-all 50)
+         (lazy/upmap cpu-pool (partial create-projections-and-save projection-config))
+         vec)))

--- a/src/clj/witan/send/send.clj
+++ b/src/clj/witan/send/send.clj
@@ -41,5 +41,6 @@
 (defn input-analysis
   ([config]
    (reset-send-report)
-   (-> (build-input-datasets (:project-dir config) (:file-inputs config) (:schema-inputs config))
-       (p/prepare-send-inputs (:transition-parameters config)))))
+   (let [print-warnings? true]
+     (-> (build-input-datasets (:project-dir config) (:file-inputs config) (:schema-inputs config))
+         (p/prepare-send-inputs (:transition-parameters config) print-warnings?)))))

--- a/src/clj/witan/send/step.clj
+++ b/src/clj/witan/send/step.clj
@@ -2,7 +2,7 @@
   (:require [witan.send.constants :as c]))
 
 (defn age-population
-  [projection model-state]
+  [model-state]
   (reduce (fn [coll [[year state] population]]
             (cond-> coll
               (< year c/max-academic-year)

--- a/test/witan/send/model/prepare_test.clj
+++ b/test/witan/send/model/prepare_test.clj
@@ -5,6 +5,29 @@
             [witan.send.model.prepare :as sut]
             [witan.send.send :as send]))
 
+(deftest test-initial-send-pop
+  (testing "Simple transformation"
+    (is (= (sut/create-initial-send-pop 2018
+                                        [{:calendar-year 2017
+                                          :academic-year-1 0 :need-1 :N1 :setting-1 :S1
+                                          :academic-year-2 1 :need-2 :N1 :setting-2 :S1}
+                                         {:calendar-year 2018
+                                          :academic-year-1 1 :need-1 :N1 :setting-1 :S1
+                                          :academic-year-2 2 :need-2 :N1 :setting-2 :S1}
+                                         {:calendar-year 2018
+                                          :academic-year-1 1 :need-1 :N1 :setting-1 :S1
+                                          :academic-year-2 2 :need-2 :N1 :setting-2 :S1}
+                                         {:calendar-year 2018
+                                          :academic-year-1 1 :need-1 :N2 :setting-1 :S2
+                                          :academic-year-2 2 :need-2 :N1 :setting-2 :S2}
+                                         {:calendar-year 2018
+                                          :academic-year-1 1 :need-1 :N1 :setting-1 :S2
+                                          :academic-year-2 2 :need-2 :N1 :setting-2 :S2}
+                                         {:calendar-year 2018
+                                          :academic-year-1 1 :need-1 :N1 :setting-1 :S2
+                                          :academic-year-2 2 :need-2 :NONSEND :setting-2 :NONSEND}])
+           {[2 :N1-S1] 2, [2 :N1-S2] 2}))))
+
 (deftest test-predicates-test
   (testing "filter by single key-value pair"
     (is (every? true? (sut/test-predicates {:a 1 :b 2 :c 3} {:a 1})))


### PR DESCRIPTION
# Problem Statement

The current construction of the SEND model does lots of data manipulation inside particular functions in the overall run pipeline. This makes it very difficult to figure out what is happening in each step and inspect the results, and makes it difficult to change the flow, by either directly manipulating things or by changing some of the inputs.

Furthermore, many outputs are calculated that aren't used by our current reporting system. It is also difficult to access the simulations in RAM instead we tend to re-read them from disk.

# Proposal

Tease apart loading the inputs, training the model, and running the model. While the first attempt may not be flexible enough, it should expose enough of the workings that we become comfortable with changing the transitions we learn from, changing the learned distributions from the transitions and working more quickly with the results in tools like goal-seek.

# Goal

A more flexible model that is faster to run allowing us to do more exploration around results and scenarios.