### PR TITLE
Fix/read config

### DIFF
--- a/src/clj/witan/send/main.clj
+++ b/src/clj/witan/send/main.clj
@@ -23,10 +23,10 @@
   [config-path]
   (let [project-dir (or (.getParent (io/as-file config-path))
                         (System/getProperty "user.dir"))]
-    (merge (aero/read-config config-path)
-           default-schemas
+    (merge default-schemas
            {:project-dir project-dir}
-           {:output-parameters {:project-dir project-dir}})))
+           {:output-parameters {:project-dir project-dir}}
+           (aero/read-config config-path))))
 
 (defn get-output-dir [config]
   (string/join "/" [(:project-dir config)

--- a/src/clj/witan/send/main.clj
+++ b/src/clj/witan/send/main.clj
@@ -23,11 +23,10 @@
   [config-path]
   (let [project-dir (or (.getParent (io/as-file config-path))
                         (System/getProperty "user.dir"))]
-    (merge-with merge
-                (aero/read-config config-path)
-                default-schemas
-                {:project-dir project-dir}
-                {:output-parameters {:project-dir project-dir}})))
+    (merge (aero/read-config config-path)
+           default-schemas
+           {:project-dir project-dir}
+           {:output-parameters {:project-dir project-dir}})))
 
 (defn get-output-dir [config]
   (string/join "/" [(:project-dir config)


### PR DESCRIPTION
After testing found that `merge-with` wasn't really needed here.

Changed order of merging of maps so that the contents of the config file always trumps anything added by `read-config`