### PR TITLE
Removing age defs from domain.academic-years

### DIFF
--- a/src/clj/witan/send/domain/academic_years.clj
+++ b/src/clj/witan/send/domain/academic_years.clj
@@ -1,21 +1,5 @@
 (ns witan.send.domain.academic-years)
 
-
-(defn ncy->age [ncy]
-  (+ ncy 5))
-
-(defn age->ncy [age]
-  (- age 5))
-
-(defn age-group [age]
-  (cond
-    (< age 5) "Age 0 to 5"
-    (<= 5 age 10) "Age 05 to 10"
-    (<= 11 age 15) "Age 11 to 15"
-    (<= 16 age 19) "Age 16 to 19"
-    (<= 20 age 25) "Age 20 to 25"
-    (< 25 age) "Over 25"))
-
 (def ay-lookup
   (sorted-map -5 -5
               -4 -4


### PR DESCRIPTION
- Delete ncy->age and age->ncy which were using an offset of 5 (i.e. age at end of school year, or average age mid-school-year) rather than 4. For mose DfE uses age on 31-Aug prior to the start of the school year is relevant: for that use new witan.send.adriddiad.ncy/ncy->age-at-start-of-school-year.
- Delete age-group as these are defined in witan.send.adroddiad.dsg-plan.