### PR TITLE
Throw error if joiners or population data missing

### DIFF
--- a/src/clj/witan/send/params.clj
+++ b/src/clj/witan/send/params.clj
@@ -111,7 +111,7 @@
         (fn [coll cy]
           (let [j (get-in joiners [cy ay])
                 p (get-in population [cy ay])]
-            (if j
+            (if (and j p)
               (-> coll
                   (update-in [ay :alpha] m/some+ (/ j n))
                   (update-in [ay :beta] m/some+ (/ (- p j) n)))


### PR DESCRIPTION
This will throw the same error message which is helpful, when either joiner and/or population is not present